### PR TITLE
feat: 비밀번호 재설정 API 구현 및 인증 로직 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // swagger
+	// 비밀번호 재설정 시 이메일 발송 로직
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 

--- a/src/main/java/com/example/kuriq/config/SecurityConfig.java
+++ b/src/main/java/com/example/kuriq/config/SecurityConfig.java
@@ -42,7 +42,10 @@ public class SecurityConfig {
                                 "/api/v1/auth/login",
                                 "/api/v1/auth/logout",
                                 "/api/v1/auth/refresh",
-                                "/api/v1/roadmap/generate"
+                                "/api/v1/roadmap/generate",
+                                // 비밀번호 재설정할 때 인증 없이 접근 가능하게
+                                "/api/v1/auth/password-reset/request",
+                                "/api/v1/auth/password-reset/confirm"
                         ).permitAll()
                         // Swagger UI 허용
                         .requestMatchers(

--- a/src/main/java/com/example/kuriq/controller/AuthController.java
+++ b/src/main/java/com/example/kuriq/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.example.kuriq.controller;
 
+import com.example.kuriq.dto.user.request.PasswordResetConfirmRequest;
+import com.example.kuriq.dto.user.request.PasswordResetRequest;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 
@@ -113,5 +115,25 @@ public class AuthController {
         return (forwarded != null && !forwarded.isBlank())
                 ? forwarded.split(",")[0].trim()
                 : req.getRemoteAddr();
+    }
+
+    // 비밀번호 재설정 요청(이메일 입력 → 토큰 생성 및 이메일 발송)
+    @Operation(summary = "비밀번호 재설정 요청")
+    @PostMapping("/password-reset/request")
+    public ResponseEntity<Void> requestPasswordReset(
+            @Valid @RequestBody PasswordResetRequest req) {
+        authService.requestPasswordReset(req.getEmail());  // 이메일로 재설정 토큰 생성 및 발송 처리
+        return ResponseEntity.noContent().build();  // 성공 시 204 No Content 반환 (응답 바디 없음)
+    }
+
+    // 비밀번호 재설정 확인(토큰 검증 → 새 비밀번호로 변경)
+    @Operation(summary = "비밀번호 재설정 확인")
+    @PostMapping("/password-reset/confirm")
+    public ResponseEntity<Void> confirmPasswordReset(
+            @Valid @RequestBody PasswordResetConfirmRequest req) {
+        // 토큰 검증 후 비밀번호 변경 처리
+        authService.confirmPasswordReset(req.getToken(), req.getNewPassword());
+        // 성공 시 204 No Content 반환
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/kuriq/entity/User/PasswordResetToken.java
+++ b/src/main/java/com/example/kuriq/entity/User/PasswordResetToken.java
@@ -62,7 +62,7 @@ public class PasswordResetToken {
     @PrePersist
     private void prePersist() { createdAt = LocalDateTime.now(); }
 
-    // 토큰 생성 메서드 (팩토리 메서드)
+    // 토큰 생성 메서드
     // userId, tokenHash를 받아서 객체 생성
     // 만료 시간은 현재 기준 +1시간으로 설정
     public static PasswordResetToken create(String userId, String tokenHash) {
@@ -80,7 +80,7 @@ public class PasswordResetToken {
     }
 
     // 토큰 사용 처리
-    // 사용 완료 시 true로 변경 → 재사용 방지
+    // 사용 완료 시 true로 변경해서 재사용 방지
     public void markUsed() { this.used = true; }
 }
 

--- a/src/main/java/com/example/kuriq/entity/User/User.java
+++ b/src/main/java/com/example/kuriq/entity/User/User.java
@@ -112,4 +112,9 @@ public class User {
         this.isDeleted = false;
         this.deletedAt = null;
     }
+
+    // 비밀번호 변경
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/example/kuriq/service/AuthService.java
+++ b/src/main/java/com/example/kuriq/service/AuthService.java
@@ -4,16 +4,19 @@ import com.example.kuriq.dto.user.request.LoginRequest;
 import com.example.kuriq.dto.user.request.SignupRequest;
 import com.example.kuriq.entity.notification.NotificationSetting;
 import com.example.kuriq.entity.user.LoginAttempt;
+import com.example.kuriq.entity.user.PasswordResetToken;
 import com.example.kuriq.entity.user.RefreshToken;
 import com.example.kuriq.entity.user.User;
 import com.example.kuriq.repository.notification.NotificationSettingRepository;
 import com.example.kuriq.repository.user.LoginAttemptRepository;
+import com.example.kuriq.repository.user.PasswordResetTokenRepository;
 import com.example.kuriq.repository.user.RefreshTokenRepository;
 import com.example.kuriq.repository.user.UserRepository;
 import com.example.kuriq.security.JwtProvider;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -21,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.HexFormat;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -32,6 +36,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
     private final NotificationSettingRepository notificationSettingRepository;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final EmailService emailService;  // 비번 재설정 시 이메일 발송 필드
 
     // 회원가입
     public String signup(SignupRequest req) {
@@ -40,6 +46,13 @@ public class AuthService {
 
         if (existing != null) {
             if (!existing.getIsDeleted()) {
+                // 소셜 계정으로 가입된 경우 별도 안내
+                if (existing.getAuthProvider() != User.AuthProvider.LOCAL) {
+                    throw new IllegalArgumentException(
+                            "이미 " + existing.getAuthProvider() + " 계정으로 가입된 이메일입니다. 해당 계정으로 로그인해 주세요."
+                    );
+                }
+
                 throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
             }
             // soft delete된 계정이면 재활성화
@@ -78,6 +91,14 @@ public class AuthService {
                     loginAttemptRepository.save(LoginAttempt.of(req.getEmail(), false, ip));
                     return new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
                 });
+
+        // 소셜 전용 계정 체크(소셜 계정은 password가 null이라서 비번 체크 앞에 와야 함)
+        if (user.getAuthProvider() != User.AuthProvider.LOCAL) {
+            throw new IllegalArgumentException(
+                    "이 이메일은 " + user.getAuthProvider() + " 로그인으로 가입되었습니다. "
+                            + user.getAuthProvider() + " 로그인을 이용해 주세요."
+            );
+        }
 
         if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
             loginAttemptRepository.save(LoginAttempt.of(req.getEmail(), false, ip));
@@ -140,5 +161,51 @@ public class AuthService {
         } catch (Exception e) {
             throw new RuntimeException("해시 생성 실패", e);
         }
+    }
+
+    // 비밀번호 재설정 요청
+    public void requestPasswordReset(String email) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(email).orElse(null);
+
+        // 보안상 존재하지 않는 이메일도 성공 응답 반환 (이메일 존재 여부 노출 방지)
+        if (user == null) return;
+
+        // 소셜 로그인 전용 계정은 비밀번호 재설정 불가
+        if (user.getAuthProvider() != User.AuthProvider.LOCAL) {
+            throw new IllegalArgumentException(
+                    "이 계정은 " + user.getAuthProvider() + " 로그인으로 가입되었습니다. "
+                            + user.getAuthProvider() + "에서 비밀번호를 관리해 주세요."
+            );
+        }
+
+        // 기존 미사용 토큰 무효화
+        passwordResetTokenRepository.invalidatePreviousTokens(user.getId());
+
+        // 새 토큰 생성
+        String rawToken = java.util.UUID.randomUUID().toString();
+        passwordResetTokenRepository.save(
+                PasswordResetToken.create(user.getId(), sha256(rawToken)) // DB에 해시로 저장
+        );
+
+        // 이메일 발송
+        emailService.sendPasswordResetEmail(email, rawToken);
+    }
+
+    // 비밀번호 재설정 확인
+    public void confirmPasswordReset(String rawToken, String newPassword) {
+        PasswordResetToken resetToken = passwordResetTokenRepository
+                // 사용자가 보내온 토큰을 해시 처리해서 DB에 저장된 해시값과 비교해 토큰 찾음
+                .findByTokenHash(sha256(rawToken))
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰입니다."));
+
+        if (!resetToken.isValid()) {
+            throw new IllegalArgumentException("만료되었거나 이미 사용된 토큰입니다.");
+        }
+
+        User user = userRepository.findById(resetToken.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        user.changePassword(passwordEncoder.encode(newPassword));  // passwordEncoder로 암호화된 새 비밀번호를 받아 교체
+        resetToken.markUsed();  // 재사용 방지
     }
 }

--- a/src/main/java/com/example/kuriq/service/EmailService.java
+++ b/src/main/java/com/example/kuriq/service/EmailService.java
@@ -1,0 +1,28 @@
+package com.example.kuriq.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    // 비밀번호 재설정 이메일 발송
+    public void sendPasswordResetEmail(String toEmail, String rawToken) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("[큐릭] 비밀번호 재설정 안내");
+        message.setText(
+                "비밀번호 재설정을 요청하셨습니다.\n\n" +
+                        "아래 토큰을 비밀번호 재설정 확인 화면에 입력해 주세요.\n\n" +
+                        "토큰: " + rawToken + "\n\n" +
+                        "이 토큰은 1시간 후 만료됩니다.\n" +
+                        "본인이 요청하지 않으셨다면 이 메일을 무시해 주세요."
+        );
+        mailSender.send(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,4 +31,11 @@ jwt.expiration=3600000
 jwt.access-token-expiry=3600000
 jwt.refresh-token-expiry=1209600000
 
+// 비밀번호 재설정 시 이메일 발송 로직 SMTP 설정
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=hyunjung26@skuniv.ac.kr
+spring.mail.password=fniy xpjl olaf oguz
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
 


### PR DESCRIPTION
## 변경 사항
- PasswordResetRequest, PasswordResetConfirmRequest DTO 추가
- AuthService 비밀번호 재설정 요청/확인 로직 추가
- AuthController 비밀번호 재설정 엔드포인트 추가
- User 엔티티 changePassword() 메서드 추가
- SecurityConfig 비밀번호 재설정 엔드포인트 permitAll 추가
- EmailService 추가 및 Gmail SMTP 이메일 발송 구현
- AuthService 소셜 계정 이메일 중복/로그인 시도 차단 추가

## 테스트
- 비밀번호 재설정 요청 → 이메일 수신 확인
- 비밀번호 재설정 확인 → 새 비밀번호로 로그인 확인