### PR TITLE
feat: 위치 기반 학습 공간 조회 API 구현

### DIFF
--- a/src/main/java/com/example/kuriq/controller/StudySpaceController.java
+++ b/src/main/java/com/example/kuriq/controller/StudySpaceController.java
@@ -1,0 +1,54 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.space.response.StudySpaceResponse;
+import com.example.kuriq.service.StudySpaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "StudySpace", description = "학습 공간 API")
+@SecurityRequirement(name = "bearerAuth") // Swagger에서 JWT 인증 필요한 API라고 표시됨
+@RestController
+@RequestMapping("/api/v1/spaces")
+@RequiredArgsConstructor
+@Validated  // min이 동작하게 하기 위한 어노테이션
+public class StudySpaceController {
+
+    private final StudySpaceService studySpaceService;
+
+    // GET /api/v1/spaces/nearby?lat=37.5&lng=127.0&radius=2000
+    // 현재 위치 기반으로 주변 학습 공간을 거리순으로 최대 20개 반환
+    @Operation(
+            summary = "주변 학습 공간 조회",
+            description = "현재 위치(위도/경도) 기준 반경 내 학습 공간을 거리순으로 반환합니다. " +
+                    "공공 공간(도서관/평생학습관/50플러스)이 3개 미만이면 카페를 보조로 추가합니다. 최대 20개."
+    )
+    @GetMapping("/nearby")
+    public ResponseEntity<List<StudySpaceResponse>> getNearbySpaces(
+            @Parameter(description = "현재 위치 위도", example = "37.5172", required = true) // swagger 문서 설명
+            @RequestParam double lat,
+
+            @Parameter(description = "현재 위치 경도", example = "127.0473", required = true)
+            @RequestParam double lng,
+
+            @Parameter(description = "검색 반경(m). 기본 2000, 최대 5000", example = "2000")
+            @RequestParam(required = false) @Min(value = 1, message = "반경은 1m 이상이어야 합니다") Integer radius,
+
+            // JWT 인증에서 추출한 userId — 인증 확인 용도 (실제 조회에는 미사용)
+            @AuthenticationPrincipal String userId
+    ) {
+        return ResponseEntity.ok(studySpaceService.getNearbySpaces(lat, lng, radius));
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/space/response/StudySpaceResponse.java
+++ b/src/main/java/com/example/kuriq/dto/space/response/StudySpaceResponse.java
@@ -1,0 +1,66 @@
+package com.example.kuriq.dto.space.response;
+
+import com.example.kuriq.entity.space.StudySpace;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "학습 공간 조회 응답")
+public class StudySpaceResponse {
+
+    @Schema(description = "공간 ID", example = "uuid-1234")
+    private String id;
+
+    @Schema(description = "공간 이름", example = "강남구립 논현도서관")
+    private String name;
+
+    // LIBRARY / LIFELONG_LEARNING / FIFTY_PLUS / CAFE 중 하나
+    @Schema(description = "공간 유형", example = "LIBRARY")
+    private String type;
+
+    @Schema(description = "주소", example = "서울 강남구 학동로 326")
+    private String address;
+
+    @Schema(description = "위도", example = "37.5172")
+    private java.math.BigDecimal latitude;
+
+    @Schema(description = "경도", example = "127.0473")
+    private java.math.BigDecimal longitude;
+
+    @Schema(description = "운영 시간", example = "평일 09:00~18:00 / 주말 휴무")
+    private String operatingHours;
+
+    @Schema(description = "전화번호", example = "02-1234-5678")
+    private String phone;
+
+    @Schema(description = "와이파이 여부", example = "true")
+    private Boolean hasWifi;
+
+    @Schema(description = "콘센트 여부", example = "false")
+    private Boolean hasPowerOutlet;
+
+    // 요청 위치 기준 거리(미터), 소수점 없이 정수로 반환
+    @Schema(description = "현재 위치 기준 거리(m)", example = "450")
+    private Integer distanceMeters;
+
+    // Entity → DTO 변환 메서드
+    // 거리값을 응답에 포함시키기 위해 distanceMeters 추가
+    // distanceMeters는 Service에서 Haversine으로 계산한 값을 넘겨받음
+    public static StudySpaceResponse from(StudySpace space, double distanceMeters) {
+        return StudySpaceResponse.builder()
+                .id(space.getId())
+                .name(space.getName())
+                .type(space.getType().name())
+                .address(space.getAddress())
+                .latitude(space.getLatitude())
+                .longitude(space.getLongitude())
+                .operatingHours(space.getOperatingHours())
+                .phone(space.getPhone())
+                .hasWifi(space.getHasWifi())
+                .hasPowerOutlet(space.getHasPowerOutlet())
+                .distanceMeters((int) Math.round(distanceMeters))
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/space/StudySpace.java
+++ b/src/main/java/com/example/kuriq/entity/space/StudySpace.java
@@ -1,0 +1,87 @@
+package com.example.kuriq.entity.space;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "study_spaces",
+        indexes = {
+                @Index(name = "idx_spaces_location", columnList = "latitude, longitude"),
+                @Index(name = "idx_spaces_type'", columnList = "type"),
+                @Index(name = "idx_spaces_active", columnList = "isActive"), // TODO: DB 컬럼명으로 교체 고려
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudySpace {
+
+    // 공간 ID
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 공간 이름
+    @Column(nullable = false)
+    private String name;
+
+    // 공간 유형
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SpaceType type;
+
+    // 주소
+    @Column(nullable = false, length = 500)
+    private String address;
+
+    // 위도
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    // 경도
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    // 운영 시간
+    @Column(length = 500)
+    private String operatingHours;
+
+    // 전화번호
+    @Column(length = 20)
+    private String phone;
+
+    // 와이파이 제공 여부
+    private Boolean hasWifi = false;
+
+    // 콘센트 제공 여부
+    private Boolean hasPowerOutlet = false;
+
+    // 활성화 여부(false면 검색 결과에서 제외)
+    private Boolean is_active = true;
+
+    // 데이터 마지막 갱신 시각
+    private LocalDateTime lastUpdatedAt;
+
+    // DB insert 시각
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public enum SpaceType {
+        LIBRARY,
+        LIFELONG_LEARNING,
+        FIFTY_PLUS,
+        CAFE
+    }
+}

--- a/src/main/java/com/example/kuriq/repository/space/StudySpaceRepository.java
+++ b/src/main/java/com/example/kuriq/repository/space/StudySpaceRepository.java
@@ -1,0 +1,54 @@
+package com.example.kuriq.repository.space;
+
+import com.example.kuriq.entity.space.StudySpace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StudySpaceRepository extends JpaRepository<StudySpace, String> {
+
+    // 반경 내 공공 공간(도서관, 평생학습관, 50플러스)만 거리순 조회 (최대 20개)
+    // 카페는 규칙상 따로 조회
+    // 여기서는 반경 내 공간만 조회, 거리 계산은 service에서
+    @Query(value = """
+        SELECT *
+        FROM study_spaces
+        WHERE is_active = true  -- 활성화된 공간만
+          AND type != 'CAFE'
+          AND (
+            6371000 * acos(
+                cos(radians(:lat)) * cos(radians(latitude))
+                * cos(radians(longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(latitude))
+            )
+          ) <= :radius  -- 반경 제한 ex) radius == 3000 이면 3km 이내만 조회
+        """, nativeQuery = true)
+    List<StudySpace> findPublicSpacesNearby(
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("radius") int radius
+    );
+
+    // 반경 내 카페만 거리순 조회
+    // 공공 공간이 3개 미만일 때 보조로 추가
+    @Query(value = """
+        SELECT *
+        FROM study_spaces
+        WHERE is_active = true
+          AND type = 'CAFE'
+          AND (
+            6371000 * acos(
+                cos(radians(:lat)) * cos(radians(latitude))
+                * cos(radians(longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(latitude))
+            )
+          ) <= :radius
+        """, nativeQuery = true)
+    List<StudySpace> findCafesNearby(
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("radius") int radius
+    );
+}

--- a/src/main/java/com/example/kuriq/service/StudySpaceService.java
+++ b/src/main/java/com/example/kuriq/service/StudySpaceService.java
@@ -1,0 +1,72 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.space.response.StudySpaceResponse;
+import com.example.kuriq.entity.space.StudySpace;
+import com.example.kuriq.repository.space.StudySpaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 조회 전용이라 readOnly → 성능 최적화
+public class StudySpaceService {
+
+    private final StudySpaceRepository studySpaceRepository;
+
+    // 반경 기본값: 2000m / 최대값: 5000m
+    private static final int DEFAULT_RADIUS = 2000;
+    private static final int MAX_RADIUS     = 5000;
+
+    // 공공 공간이 이 수 미만이면 카페를 보조로 추가
+    private static final int PUBLIC_SPACE_MIN = 3;
+
+    // 위치 기반 주변 학습 공간 조회
+    // 처리 순서:
+    //   1) 공공 공간(도서관, 평생학습관, 50플러스) 먼저 조회
+    //   2) 공공 공간이 3개 미만이면 카페를 추가로 조회해서 합침
+    //   3) 합친 목록을 거리순으로 재정렬 후 최대 20개 반환
+    public List<StudySpaceResponse> getNearbySpaces(double lat, double lng, Integer radius) {
+
+        // 반경 유효성 처리: null이면 기본값, MAX_RADIUS 초과 시 최대값으로 고정
+        int effectiveRadius = (radius == null) ? DEFAULT_RADIUS : Math.min(radius, MAX_RADIUS);
+
+        // 공공 공간 먼저 조회
+        List<StudySpace> publicSpaces = studySpaceRepository.findPublicSpacesNearby(lat, lng, effectiveRadius);
+        List<StudySpace> result = new ArrayList<>(publicSpaces);
+
+        // 공공 공간이 기준치 미만이면 카페를 보조로 추가
+        if (publicSpaces.size() < PUBLIC_SPACE_MIN) {
+            List<StudySpace> cafes = studySpaceRepository.findCafesNearby(lat, lng, effectiveRadius);
+            result.addAll(cafes);
+        }
+
+        // 각 공간까지의 거리를 Haversine으로 계산 후 DTO 변환
+        // 공공 + 카페 합쳤을 때 전체 거리순 보장을 위해 재정렬
+        return result.stream()
+                .map(space -> {
+                    double dist = haversine(lat, lng,
+                            space.getLatitude().doubleValue(),   // BigDecimal → double
+                            space.getLongitude().doubleValue()); // -> BigDecimal은 수학 계산 메서드에 바로 못 넣음
+                    return StudySpaceResponse.from(space, dist);
+                })
+                .sorted((a, b) -> Integer.compare(a.getDistanceMeters(), b.getDistanceMeters()))
+                .limit(20) // 최대 20개 제한
+                .toList();
+    }
+
+    // Haversine 공식: 두 위경도 좌표 사이의 지표면 거리(미터) 계산
+    // 지구 반지름 6,371,000m 기준
+    private double haversine(double lat1, double lng1, double lat2, double lng2) {
+        final int R = 6_371_000;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    }
+}


### PR DESCRIPTION
## 개요
위치 기반으로 주변 학습 공간을 조회하는 API 구현

## 구현 내용
- StudySpace 엔티티 생성
- StudySpaceRepository — Haversine 공식 기반 반경 내 공간 조회
- StudySpaceService — 공공 공간 우선 노출, 3개 미만 시 카페 보조 추가
- StudySpaceController — GET /api/v1/spaces/nearby

## 비즈니스 규칙
- 공공 공간(도서관/평생학습관/50플러스) 우선 노출
- 공공 공간 3개 미만 시 카페 보조 표시
- 거리순 정렬, 최대 20개 반환
- 반경 기본 2000m, 최대 5000m

## 연관 이슈
close #이슈번호