### PR TITLE
feat: 학습 통계 및 이력 조회 API 구현

### DIFF
--- a/src/main/java/com/example/kuriq/controller/UserController.java
+++ b/src/main/java/com/example/kuriq/controller/UserController.java
@@ -4,14 +4,14 @@ package com.example.kuriq.controller;
 import com.example.kuriq.dto.notification.request.NotificationUpdateRequest;
 import com.example.kuriq.dto.notification.response.NotificationResponse;
 import com.example.kuriq.dto.user.request.DeleteAccountRequest;
-import com.example.kuriq.dto.user.response.SocialAccountResponse;
+import com.example.kuriq.dto.user.response.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
-import com.example.kuriq.dto.user.response.UserResponse;
 import com.example.kuriq.service.UserService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -76,6 +76,36 @@ public class UserController {
             @AuthenticationPrincipal String userId,
             @Valid @RequestBody NotificationUpdateRequest req) {
         return ResponseEntity.ok(userService.updateNotificationSettings(userId, req));
+    }
+
+    // 이수 강좌 수, 총 학습 시간, 연속 학습일, 완료 로드맵 수 반환
+    @Operation(summary = "학습 통계 조회",
+            description = "이수 강좌 수 / 총 학습 시간 / 연속 학습일 / 완료 로드맵 수를 반환합니다.")
+    @GetMapping("/me/stats")
+    public ResponseEntity<UserStatsResponse> getStats(
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(userService.getStats(userId));
+    }
+
+    // 카테고리별 이수 강좌 수 + 상대 진행률 반환
+    // 가장 많이 이수한 카테고리 = 100% 기준으로 정규화
+    @Operation(summary = "분야별 학습 현황",
+            description = "카테고리별 이수 강좌 수와 상대 진행률(%)을 반환합니다.")
+    @GetMapping("/me/stats/categories")
+    public ResponseEntity<List<CategoryStatsResponse>> getCategoryStats(
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(userService.getCategoryStats(userId));
+    }
+
+    // 이수 완료한 강좌 목록 최신순 페이징 반환
+    @Operation(summary = "학습 이력 조회",
+            description = "이수 완료한 강좌 목록을 최신순으로 페이징하여 반환합니다.")
+    @GetMapping("/me/history")
+    public ResponseEntity<List<LearningHistoryResponse>> getLearningHistory(
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") @Max(value = 50, message = "size는 최대 50까지 가능합니다") int size) {
+        return ResponseEntity.ok(userService.getLearningHistory(userId, page, size));
     }
 
 }

--- a/src/main/java/com/example/kuriq/dto/user/response/CategoryStatsResponse.java
+++ b/src/main/java/com/example/kuriq/dto/user/response/CategoryStatsResponse.java
@@ -1,0 +1,27 @@
+package com.example.kuriq.dto.user.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "분야별 학습 현황 응답")
+public class CategoryStatsResponse {
+
+    // 사용자가 가장 많이 학습한 분야
+    // courses 테이블의 category 값을 기준으로 집계
+    @Schema(description = "카테고리명", example = "프로그래밍")
+    private String category;
+
+    // 해당 카테고리에서 완료한 강좌 개수
+    // learning_history 기준으로 COUNT(*) 집계 결과
+    @Schema(description = "이수 강좌 수", example = "4")
+    private long completedCount;
+
+    // 사용자가 어떤 분야를 주로 학습했는지 보여주기 위한 상대 비율
+    // 계산 방식:
+    // (현재 카테고리 이수 수 / 가장 많이 이수한 카테고리 수) * 100
+    @Schema(description = "상대 진행률(%)", example = "80.0")
+    private double progressPercent;
+}

--- a/src/main/java/com/example/kuriq/dto/user/response/LearningHistoryResponse.java
+++ b/src/main/java/com/example/kuriq/dto/user/response/LearningHistoryResponse.java
@@ -1,0 +1,67 @@
+package com.example.kuriq.dto.user.response;
+
+import com.example.kuriq.entity.roadmap.LearningHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/* 학습 이력 목록 응답 DTO. 강좌명, 플랫폼, 이수일 포함 */
+
+@Getter
+@Builder
+@Schema(description = "학습 이력 응답")
+public class LearningHistoryResponse {
+
+    // 학습 이력 ID
+    @Schema(description = "이력 ID", example = "uuid-5678")
+    private String id;
+
+    // 이수한 강좌 ID (Course 엔티티 참조용)
+    @Schema(description = "강좌 ID", example = "uuid-course-1")
+    private String courseId;
+
+    // 프론트에서 바로 강좌명을 보여주기 위한 값
+    @Schema(description = "강좌명", example = "파이썬 기초")
+    private String courseTitle;
+
+    // 강좌 출처 플랫폼
+    // 예: K-MOOC, KOCW, 서울시 평생학습포털 등
+    @Schema(description = "플랫폼", example = "K-MOOC")
+    private String platform;
+
+    // 강좌 분야 정보
+    // 마이페이지 학습 통계나 카테고리 분석에 활용 가능
+    // TODO: 카테고리는 빼도 됨. 그냥 추가한거
+    @Schema(description = "카테고리", example = "프로그래밍")
+    private String category;
+
+    // 사용자가 해당 강좌를 완료 처리한 시각
+    @Schema(description = "이수 완료 시각", example = "2026-04-16T10:00:00")
+    private LocalDateTime completedAt;
+
+    // 어떤 로드맵을 통해 학습했는지 기록하기 위한 값
+    // 로드맵 삭제 후에도 이력은 남겨야 하므로 FK 대신 값만 저장
+    @Schema(description = "출처 로드맵 ID", example = "uuid-roadmap-1")
+    private String sourceRoadmapId;
+
+    // Entity → DTO 변환 메서드
+    // courseTitle/platform/category는 LearningHistory 테이블에 없어서
+    // Service에서 Course 조회 후 같이 넘겨받음
+    public static LearningHistoryResponse from(LearningHistory h,
+                                               String courseTitle,
+                                               String platform,
+                                               String category) {
+
+        return LearningHistoryResponse.builder()
+                .id(h.getId())
+                .courseId(h.getCourseId())
+                .courseTitle(courseTitle)
+                .platform(platform)
+                .category(category)
+                .completedAt(h.getCompletedAt())
+                .sourceRoadmapId(h.getSourceRoadmapId())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/user/response/UserStatsResponse.java
+++ b/src/main/java/com/example/kuriq/dto/user/response/UserStatsResponse.java
@@ -1,0 +1,31 @@
+package com.example.kuriq.dto.user.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/* 사용자 학습 통계 응답 DTO (이수 강좌 수, 총 학습 시간, 연속 학습일, 완료 로드맵 수) */
+
+@Getter
+@Builder
+@Schema(description = "학습 통계 응답")
+public class UserStatsResponse {
+
+    // learning_history 테이블 COUNT(*) 결과
+    @Schema(description = "총 이수 강좌 수", example = "12")
+    private long totalCompletedCourses;
+
+    // 이수한 강좌의 courses.estimated_hours 합산
+    @Schema(description = "총 학습 시간(시간)", example = "36.5")
+    private BigDecimal totalLearningHours;
+
+    // learning_history.completed_at 날짜 기준 오늘부터 연속으로 학습한 일수
+    @Schema(description = "현재 연속 학습 일수", example = "5")
+    private int streakDays;
+
+    // roadmaps 테이블에서 is_completed = true 카운트
+    @Schema(description = "완료한 로드맵 수", example = "2")
+    private long completedRoadmapCount;
+}

--- a/src/main/java/com/example/kuriq/repository/roadmap/LearningHistoryRepository.java
+++ b/src/main/java/com/example/kuriq/repository/roadmap/LearningHistoryRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -26,19 +28,47 @@ import java.util.List;
  */
 public interface LearningHistoryRepository extends JpaRepository<LearningHistory, String> {
 
-    // 사용자의 학습 이력을 최신순으로 조회
-    // 사용처: 마이페이지 최근 학습 기록 리스트
+    // 사용자 이력 최신순 전체 조회
+    // 연속 학습일 계산할 때 completedAt 날짜 뽑으려고 씀
     List<LearningHistory> findByUserIdOrderByCompletedAtDesc(String userId);
 
-    // 사용자의 학습 이력을 페이징하여 최신순으로 조회
-    // 사용처: 무한 스크롤 / 페이지 기반 학습 기록 조회
+    // 사용자 이력 최신순 페이징 조회
+    // GET /api/v1/users/me/history 페이지네이션용
     List<LearningHistory> findByUserIdOrderByCompletedAtDesc(String userId, Pageable pageable);
 
-    // 사용자가 이수한 강좌의 총 개수를 조회
-    // 사용처: 마이페이지 통계 (총 이수 강좌 수)
+    // 이수한 강좌 총 개수
+    // 마이페이지 통계 - 이수 강좌 수
     long countByUserId(String userId);
 
-    // 사용자가 특정 강좌를 이미 이수했는지 확인
-    // 사용처: 중복 학습 이력 방지, 동일 강좌 재추천 방지
+    // 특정 강좌 이수 여부 확인
+    // 중복 이력 방지용
     boolean existsByUserIdAndCourseId(String userId, String courseId);
+
+    // 이수 강좌들의 estimated_hours 합산
+    // courses 테이블 JOIN해서 SUM
+    // COALESCE: 이력 없으면 SUM이 null → 0으로 대체
+    @Query("""
+        SELECT COALESCE(SUM(c.estimatedHours), 0)
+        FROM LearningHistory h
+        JOIN Course c ON c.id = h.courseId
+        WHERE h.userId = :userId
+        """)
+    BigDecimal sumEstimatedHoursByUserId(@Param("userId") String userId);
+
+    // 카테고리별 이수 강좌 수 집계
+    // 마이페이지 분야별 학습 현황용
+    // category null인 강좌는 제외하고 집계
+    @Query("""
+        SELECT c.category, COUNT(h)
+        FROM LearningHistory h
+        JOIN Course c ON c.id = h.courseId
+        WHERE h.userId = :userId
+          AND c.category IS NOT NULL
+        GROUP BY c.category
+        ORDER BY COUNT(h) DESC
+        """)
+    List<Object[]> countByCategoryForUser(@Param("userId") String userId);
+
+    // courseId 목록으로 이력 배치 조회
+    List<LearningHistory> findByUserIdAndCourseIdIn(String userId, List<String> courseIds);
 }

--- a/src/main/java/com/example/kuriq/service/UserService.java
+++ b/src/main/java/com/example/kuriq/service/UserService.java
@@ -2,22 +2,36 @@ package com.example.kuriq.service;
 
 import com.example.kuriq.dto.notification.request.NotificationUpdateRequest;
 import com.example.kuriq.dto.notification.response.NotificationResponse;
+import com.example.kuriq.dto.user.response.CategoryStatsResponse;
+import com.example.kuriq.dto.user.response.LearningHistoryResponse;
 import com.example.kuriq.dto.user.response.SocialAccountResponse;
+import com.example.kuriq.dto.user.response.UserStatsResponse;
 import com.example.kuriq.entity.notification.NotificationSetting;
 import com.example.kuriq.entity.notification.UnsubscribeToken;
+import com.example.kuriq.entity.roadmap.Course;
+import com.example.kuriq.entity.roadmap.LearningHistory;
 import com.example.kuriq.entity.user.SocialAccount;
 import com.example.kuriq.entity.user.User;
 import com.example.kuriq.repository.notification.NotificationSettingRepository;
 import com.example.kuriq.repository.notification.UnsubscribeTokenRepository;
+import com.example.kuriq.repository.roadmap.CourseRepository;
+import com.example.kuriq.repository.roadmap.LearningHistoryRepository;
+import com.example.kuriq.repository.roadmap.RoadmapRepository;
 import com.example.kuriq.repository.user.RefreshTokenRepository;
 import com.example.kuriq.repository.user.SocialAccountRepository;
 import com.example.kuriq.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -32,6 +46,9 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final NotificationSettingRepository notificationSettingRepository;
     private final UnsubscribeTokenRepository unsubscribeTokenRepository;
+    private final LearningHistoryRepository learningHistoryRepository;
+    private final CourseRepository courseRepository;
+    private final RoadmapRepository roadmapRepository;
 
     // 프로필 조회
     public User getUser(String userId) {
@@ -129,5 +146,119 @@ public class UserService {
 
         // 사용한 토큰 삭제 (1회용)
         unsubscribeTokenRepository.delete(unsubscribeToken);
+    }
+
+    // 학습 통계
+    public UserStatsResponse getStats(String userId) {
+
+        // 이수 강좌 총 개수
+        // learning_history 테이블 COUNT
+        long totalCourses = learningHistoryRepository.countByUserId(userId);
+
+        // 총 학습 시간
+        // 이수한 강좌들의 estimated_hours 합산
+        BigDecimal totalHours = learningHistoryRepository.sumEstimatedHoursByUserId(userId);
+
+        // 연속 학습 일수 계산
+        // completedAt 날짜 기준으로 오늘부터 카운트
+        List<LearningHistory> histories = learningHistoryRepository
+                .findByUserIdOrderByCompletedAtDesc(userId);
+
+        int streakDays = 0;
+        if (!histories.isEmpty()) {
+
+            // completedAt에서 날짜만 추출해서 Set으로 만듦 (중복 제거)
+            Set<LocalDate> datesWithActivity = histories.stream()
+                    .map(h -> h.getCompletedAt().toLocalDate())
+                    .collect(Collectors.toSet());
+
+            LocalDate check = LocalDate.now();
+
+            // 오늘 활동이 없으면 어제부터 체크 시작
+            if (!datesWithActivity.contains(check)) {
+                check = check.minusDays(1);
+            }
+
+            // 날짜가 연속으로 존재하는 동안 하루씩 올라가며 카운트
+            while (datesWithActivity.contains(check)) {
+                streakDays++;
+                check = check.minusDays(1);
+            }
+        }
+
+        // 완료 로드맵 수
+        // roadmaps 테이블에서 is_completed = true 카운트
+        long completedRoadmaps = roadmapRepository.countByUserIdAndIsCompletedTrue(userId);
+
+        return UserStatsResponse.builder()
+                .totalCompletedCourses(totalCourses)
+                .totalLearningHours(totalHours)
+                .streakDays(streakDays)
+                .completedRoadmapCount(completedRoadmaps)
+                .build();
+    }
+
+    // 분야별 학습 현황
+    public List<CategoryStatsResponse> getCategoryStats(String userId) {
+
+        // 카테고리별 이수 강좌 수 조회
+        // 이수 수 내림차순 정렬
+        List<Object[]> rows = learningHistoryRepository.countByCategoryForUser(userId);
+
+        // 이력 없으면 빈 리스트 반환
+        if (rows.isEmpty()) return List.of();
+
+        // 가장 많이 이수한 카테고리 수를 기준으로 상대 진행률 계산
+        // 이미 내림차순 정렬이라 첫 번째 값이 최대값
+        long maxCount = ((Number) rows.get(0)[1]).longValue();
+
+        return rows.stream().map(row -> {
+            String category = (String) row[0];
+            long count      = ((Number) row[1]).longValue();
+
+            // 상대 진행률 계산 (소수점 1자리)
+            double percent = maxCount == 0 ? 0 : (double) count / maxCount * 100;
+
+            return CategoryStatsResponse.builder()
+                    .category(category)
+                    .completedCount(count)
+                    .progressPercent(Math.round(percent * 10.0) / 10.0)
+                    .build();
+        }).toList();
+    }
+
+    // 학습 이력 조회
+    public List<LearningHistoryResponse> getLearningHistory(String userId, int page, int size) {
+
+        // 최신순 페이징 조회
+        Pageable pageable = PageRequest.of(page, size);
+        List<LearningHistory> histories = learningHistoryRepository
+                .findByUserIdOrderByCompletedAtDesc(userId, pageable);
+
+        // 이력 없으면 빈 리스트 반환
+        if (histories.isEmpty()) return List.of();
+
+        // courseId 목록 추출
+        // distinct로 중복 제거 후 배치 조회 → N+1 방지
+        List<String> courseIds = histories.stream()
+                .map(LearningHistory::getCourseId)
+                .distinct()
+                .toList();
+
+        // courseId → Course Map으로 변환
+        // DTO 변환 시 Map에서 바로 꺼내 씀
+        Map<String, Course> courseMap = courseRepository.findAllById(courseIds)
+                .stream()
+                .collect(Collectors.toMap(Course::getId, c -> c));
+
+        // 이력 DTO 변환
+        // 강좌가 삭제된 경우 기본값으로 대체
+        return histories.stream().map(h -> {
+            Course course   = courseMap.get(h.getCourseId());
+            String title    = course != null ? course.getTitle()    : "삭제된 강좌";
+            String platform = course != null ? course.getPlatform() : "-";
+            String category = course != null ? course.getCategory() : "-";
+            return LearningHistoryResponse.from(h, title, platform, category);
+        }).toList();
     }
 }


### PR DESCRIPTION
## 개요
마이페이지에서 사용자의 학습 성과를 확인할 수 있도록
학습 통계 및 이력 조회 API를 구현했다.

## 구현 내용
- `GET /api/v1/users/me/stats` — 이수 강좌 수, 총 학습 시간, 연속 학습일, 완료 로드맵 수 반환
- `GET /api/v1/users/me/stats/categories` — 카테고리별 이수 강좌 수 및 상대 진행률 반환
- `GET /api/v1/users/me/history` — 이수 완료한 강좌 목록 최신순 페이징 반환

## 변경 파일
- `UserStatsResponse`, `CategoryStatsResponse`, `LearningHistoryResponse` DTO 추가
- `LearningHistoryRepository` 통계용 쿼리 메서드 추가
- `UserService` 통계/이력 메서드 추가
- `UserController` 엔드포인트 3개 추가

## 연관 이슈
close #11 