### PR TITLE
feat: 카카오 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/example/kuriq/config/SecurityConfig.java
+++ b/src/main/java/com/example/kuriq/config/SecurityConfig.java
@@ -45,8 +45,15 @@ public class SecurityConfig {
                                 "/api/v1/roadmap/generate",
                                 // 비밀번호 재설정할 때 인증 없이 접근 가능하게
                                 "/api/v1/auth/password-reset/request",
-                                "/api/v1/auth/password-reset/confirm"
+                                "/api/v1/auth/password-reset/confirm",
+                                "/api/v1/auth/social/**"
                         ).permitAll()
+
+                        // 소셜 로그인 인증 URL 요청
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/auth/social/**"
+                        ).permitAll()
+
                         // 알림 수신 거부는 PATCH 메서드로 별도 추가
                         .requestMatchers(HttpMethod.PATCH,
                                 "/api/v1/notifications/unsubscribe"

--- a/src/main/java/com/example/kuriq/controller/AuthController.java
+++ b/src/main/java/com/example/kuriq/controller/AuthController.java
@@ -1,15 +1,12 @@
 package com.example.kuriq.controller;
 
-import com.example.kuriq.dto.user.request.PasswordResetConfirmRequest;
-import com.example.kuriq.dto.user.request.PasswordResetRequest;
+import com.example.kuriq.dto.user.request.*;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 
 import com.example.kuriq.dto.user.response.AuthResponse;
-import com.example.kuriq.dto.user.request.LoginRequest;
-import com.example.kuriq.dto.user.request.SignupRequest;
 import com.example.kuriq.service.AuthService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -143,5 +140,27 @@ public class AuthController {
         authService.confirmPasswordReset(req.getToken(), req.getNewPassword());
         // 성공 시 204 No Content 반환
         return ResponseEntity.noContent().build();
+    }
+
+    // 소셜 로그인 인증 URL 요청
+    @Operation(summary = "소셜 로그인 인증 URL 요청",
+            description = "provider: kakao | google | naver. 반환된 authorizationUrl로 프론트가 리다이렉트합니다.")
+    @GetMapping("/social/{provider}/authorize")
+    public ResponseEntity<Map<String, String>> socialAuthorize(
+            @PathVariable String provider) {
+        String authorizationUrl = authService.getSocialAuthorizationUrl(provider);
+        return ResponseEntity.ok(Map.of("authorizationUrl", authorizationUrl));
+    }
+
+    // 소셜 로그인 콜백 처리
+    @Operation(summary = "소셜 로그인 콜백 처리",
+            description = "소셜 플랫폼에서 받은 code와 provider를 전달받아 JWT를 발급합니다.")
+    @GetMapping("/social/callback")
+    public ResponseEntity<AuthResponse> socialCallback(
+            @RequestParam String code,           // 카카오가 URL 파라미터로 code를 넘겨줌
+            HttpServletResponse httpRes) {
+        String[] tokens = authService.socialLogin("kakao", code);
+        setRefreshCookie(httpRes, tokens[1]);
+        return ResponseEntity.ok(AuthResponse.of(tokens[0]));
     }
 }

--- a/src/main/java/com/example/kuriq/dto/user/request/SocialCallbackRequest.java
+++ b/src/main/java/com/example/kuriq/dto/user/request/SocialCallbackRequest.java
@@ -1,0 +1,14 @@
+package com.example.kuriq.dto.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SocialCallbackRequest {
+
+    @NotBlank(message = "provider는 필수입니다 (kakao, google, naver)")
+    private String provider;  // 소셜 플랫폼 구분 (kakao / google / naver)
+
+    @NotBlank(message = "인증 code는 필수입니다")
+    private String code;      // 소셜 플랫폼에서 발급한 인증 코드
+}

--- a/src/main/java/com/example/kuriq/service/AuthService.java
+++ b/src/main/java/com/example/kuriq/service/AuthService.java
@@ -3,16 +3,12 @@ package com.example.kuriq.service;
 import com.example.kuriq.dto.user.request.LoginRequest;
 import com.example.kuriq.dto.user.request.SignupRequest;
 import com.example.kuriq.entity.notification.NotificationSetting;
-import com.example.kuriq.entity.user.LoginAttempt;
-import com.example.kuriq.entity.user.PasswordResetToken;
-import com.example.kuriq.entity.user.RefreshToken;
-import com.example.kuriq.entity.user.User;
+import com.example.kuriq.entity.user.*;
 import com.example.kuriq.repository.notification.NotificationSettingRepository;
-import com.example.kuriq.repository.user.LoginAttemptRepository;
-import com.example.kuriq.repository.user.PasswordResetTokenRepository;
-import com.example.kuriq.repository.user.RefreshTokenRepository;
-import com.example.kuriq.repository.user.UserRepository;
+import com.example.kuriq.repository.user.*;
 import com.example.kuriq.security.JwtProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +18,12 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.LocalDateTime;
 import java.util.HexFormat;
+import java.util.Map;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
@@ -38,6 +39,17 @@ public class AuthService {
     private final NotificationSettingRepository notificationSettingRepository;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final EmailService emailService;  // 비번 재설정 시 이메일 발송 필드
+    private final SocialAccountRepository socialAccountRepository;  // 소셜 계정 연동 정보 저장/조회
+    private final RestTemplate restTemplate = new RestTemplate();   // 카카오 API 호출용 HTTP 클라이언트
+
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;      // 카카오 앱 REST API 키 (application.properties에서 주입)
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String kakaoRedirectUri;   // 카카오 콘솔에 등록한 Redirect URI (application.properties에서 주입)
+
+    @Value("${oauth.kakao.client-secret}")
+    private String kakaoClientSecret;   // 카카오 클라이언트 시크릿 (토큰 요청 시 보안 검증용)
 
     // 회원가입
     public String signup(SignupRequest req) {
@@ -207,5 +219,122 @@ public class AuthService {
 
         user.changePassword(passwordEncoder.encode(newPassword));  // passwordEncoder로 암호화된 새 비밀번호를 받아 교체
         resetToken.markUsed();  // 재사용 방지
+    }
+
+    // 소셜 로그인 인증 URL 생성
+    // 프론트가 이 URL로 리다이렉트하면 카카오 로그인 페이지가 뜸
+    public String getSocialAuthorizationUrl(String provider) {
+        return switch (provider.toLowerCase()) {
+            case "kakao" -> "https://kauth.kakao.com/oauth/authorize"
+                    + "?client_id=" + kakaoClientId          // 카카오 앱 REST API 키
+                    + "&redirect_uri=" + kakaoRedirectUri    // 카카오 콘솔에 등록한 Redirect URI
+                    + "&response_type=code";                 // 인증 코드 방식
+            default -> throw new IllegalArgumentException("지원하지 않는 소셜 로그인 provider: " + provider);
+        };
+    }
+
+    // 소셜 로그인 메인 로직
+    public String[] socialLogin(String providerStr, String code) {
+        SocialAccount.Provider provider = parseProvider(providerStr); // "kakao" 문자열 → KAKAO enum 변환
+
+        // 1단계: 카카오 인증 서버에 code를 보내 accessToken 받기
+        String kakaoAccessToken = getKakaoAccessToken(code);
+
+        // 2단계: 발급받은 accessToken으로 카카오 사용자 정보 조회
+        Map<String, Object> kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
+        String socialId = String.valueOf(kakaoUserInfo.get("id"));  // 카카오 고유 사용자 ID
+        Map<String, Object> kakaoAccount = (Map<String, Object>) kakaoUserInfo.get("kakao_account");
+        String email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;  // 이메일 미동의 시 null
+        Map<String, Object> profile = kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
+        String name = profile != null ? (String) profile.get("nickname") : "카카오 사용자";  // 닉네임 없으면 기본값
+
+        // 3단계: social_accounts 테이블에서 이미 연동된 계정인지 확인
+        SocialAccount existing = socialAccountRepository
+                .findByProviderAndSocialId(provider, socialId)
+                .orElse(null);
+
+        String userId;
+        if (existing != null) {
+            // 기존 소셜 계정 -> 연결된 userId로 바로 로그인
+            userId = existing.getUserId();
+        } else {
+            // 신규 계정 -> 동일 이메일로 가입된 로컬 계정이 있는지 먼저 확인
+            User user = (email != null)
+                    ? userRepository.findByEmailAndIsDeletedFalse(email).orElse(null)
+                    : null;
+
+            if (user == null) {
+                // 완전 새 유저 생성 (소셜 전용 계정은 password = null)
+                user = User.builder()
+                        .email(email)
+                        .password(null)                          // 소셜 전용 계정은 비밀번호 없음
+                        .name(name)
+                        .authProvider(User.AuthProvider.KAKAO)   // authProvider = KAKAO로 저장
+                        .isDeleted(false)
+                        .build();
+                userRepository.save(user);
+                notificationSettingRepository.save(NotificationSetting.createDefault(user.getId()));  // 알림 설정 기본값 생성
+            }
+
+            // social_accounts 테이블에 카카오 계정 연동 정보 저장
+            socialAccountRepository.save(
+                    SocialAccount.create(user.getId(), provider, socialId, email)
+            );
+            userId = user.getId();
+        }
+
+        // 4단계: JWT 발급
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
+        saveRefreshToken(userId, refreshToken);  // refreshToken은 해시로 DB 저장
+
+        return new String[]{accessToken, refreshToken};
+    }
+
+    // 카카오 인증 서버에 code를 보내 accessToken 교환
+    private String getKakaoAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);  // 카카오 API는 form 형식 요구
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");  // 인증 코드 방식 고정값
+        body.add("client_id", kakaoClientId);          // 카카오 앱 REST API 키
+        body.add("redirect_uri", kakaoRedirectUri);    // 콘솔에 등록한 URI와 반드시 동일해야 함
+        body.add("code", code);                        // 프론트에서 받아온 인증 코드
+        body.add("client_secret", kakaoClientSecret);  // 클라이언트 시크릿 추가 (보안 강화)
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "https://kauth.kakao.com/oauth/token", request, Map.class);
+
+        if (response.getBody() == null || !response.getBody().containsKey("access_token")) {
+            throw new RuntimeException("카카오 토큰 발급 실패");
+        }
+        return (String) response.getBody().get("access_token");
+    }
+
+    // 카카오 API 서버에 accessToken을 보내 사용자 정보 조회
+    private Map<String, Object> getKakaoUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, request, Map.class);
+
+        if (response.getBody() == null) {
+            throw new RuntimeException("카카오 사용자 정보 조회 실패");
+        }
+        return response.getBody();
+    }
+
+    // provider 문자열 -> SocialAccount.Provider enum 변환
+    // "kakao" -> KAKAO, 지원하지 않는 값이면 예외 발생
+    private SocialAccount.Provider parseProvider(String provider) {
+        try {
+            return SocialAccount.Provider.valueOf(provider.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 소셜 로그인 provider: " + provider);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,14 @@
 spring.application.name=kuriq
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
-# ========================
+
 # MySQL 연결
-# ========================
 spring.datasource.url=jdbc:mysql://localhost:3306/kuriq?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# ========================
 # JPA 설정
-# ========================
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
@@ -20,18 +17,15 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 jwt.secret=kuriq-super-secret-key-2026-project-very-long-secret-key-123456789
 jwt.expiration=3600000
 
-# =========================
 # MySQL 설정
-# =========================
 
 
-# =========================
+
 # JWT 설정
-# =========================
 jwt.access-token-expiry=3600000
 jwt.refresh-token-expiry=1209600000
 
-// 비밀번호 재설정 시 이메일 발송 로직 SMTP 설정
+# 비밀번호 재설정 시 이메일 발송 로직 SMTP 설정
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=hyunjung26@skuniv.ac.kr
@@ -39,3 +33,7 @@ spring.mail.password=fniy xpjl olaf oguz
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+# 카카오 소셜 로그인 키 설정
+oauth.kakao.client-id=5d4cfd50058b6907aa5b453330e7e1c8
+oauth.kakao.redirect-uri=https://startup-chug-trembling.ngrok-free.dev/api/v1/auth/social/callback
+oauth.kakao.client-secret=MmkqKQAlxUe6U1qA9cB2nT5T4eNP0ZFX


### PR DESCRIPTION
## 개요
카카오 OAuth2.0 소셜 로그인 기능을 구현한다.

## 변경 사항

### AuthController
- GET /api/v1/auth/social/{provider}/authorize 엔드포인트 추가
  - 카카오 로그인 페이지로 리다이렉트할 인증 URL 반환
- GET /api/v1/auth/social/callback 엔드포인트 추가
  - 카카오가 GET으로 code를 전달하는 방식에 맞게 GET으로 구현
  - 기존 API 명세서의 POST → GET으로 변경 

### AuthService
- 카카오 인증 URL 생성 로직 구현
- 카카오 code → accessToken 교환 로직 구현
- 카카오 사용자 정보 조회 로직 구현
- 신규 유저 자동 가입 / 기존 유저 로그인 분기 처리
- social_accounts 테이블에 소셜 계정 연동 정보 저장

### 기타
- SocialCallbackRequest DTO 추가
- SecurityConfig에 소셜 로그인 GET 엔드포인트 permitAll 추가
- application.properties에 카카오 OAuth 설정값 추가 (client-id, redirect-uri, client-secret)

## 테스트
- ngrok으로 로컬 테스트 완료
- 카카오 로그인 → code 발급 → accessToken 발급 정상 확인

## 관련 이슈
close #13 