### PR TITLE
feat: 강좌 클릭 로깅 구현 및 Redis 인기 강좌 집계 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // swagger
-	// 비밀번호 재설정 시 이메일 발송 로직
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-mail' // 비밀번호 재설정 시 이메일 발송 로직
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis' // Redis
 }
 
 

--- a/src/main/java/com/example/kuriq/KuriqApplication.java
+++ b/src/main/java/com/example/kuriq/KuriqApplication.java
@@ -2,9 +2,11 @@ package com.example.kuriq;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
+@EnableAsync   // @Async 동작을 위해 추가 (CourseClickEventListener에서 사용)
+@EnableScheduling   // 스케줄러(@Scheduled) 동작을 위해 필요
 @SpringBootApplication
 public class KuriqApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/example/kuriq/config/SecurityConfig.java
+++ b/src/main/java/com/example/kuriq/config/SecurityConfig.java
@@ -43,15 +43,16 @@ public class SecurityConfig {
                                 "/api/v1/auth/logout",
                                 "/api/v1/auth/refresh",
                                 "/api/v1/roadmap/generate",
-                                // 비밀번호 재설정할 때 인증 없이 접근 가능하게
-                                "/api/v1/auth/password-reset/request",
+                                "/api/v1/auth/password-reset/request",  // 비밀번호 재설정할 때 인증 없이 접근 가능하게
                                 "/api/v1/auth/password-reset/confirm",
-                                "/api/v1/auth/social/**"
+                                "/api/v1/auth/social/**",
+                                "/api/v1/analytics/course-click" // 비로그인 클릭도 기록해야 하므로 인증 없이 허용
                         ).permitAll()
 
                         // 소셜 로그인 인증 URL 요청
                         .requestMatchers(HttpMethod.GET,
-                                "/api/v1/auth/social/**"
+                                "/api/v1/auth/social/**",
+                                "/api/v1/analytics/courses/popular"
                         ).permitAll()
 
                         // 알림 수신 거부는 PATCH 메서드로 별도 추가

--- a/src/main/java/com/example/kuriq/controller/AnalyticsController.java
+++ b/src/main/java/com/example/kuriq/controller/AnalyticsController.java
@@ -1,0 +1,70 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.analytics.CourseClickLogRequest;
+import com.example.kuriq.event.CourseClickEvent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Tag(name = "Analytics", description = "분석 API")
+@RestController
+@RequestMapping("/api/v1/analytics")
+@RequiredArgsConstructor
+public class AnalyticsController {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final StringRedisTemplate redisTemplate;
+
+    @Operation(summary = "강좌 클릭 로깅", description = "수강 신청 버튼 클릭 시 호출. 비로그인도 허용.")
+    @PostMapping("/course-click")
+    public ResponseEntity<Void> logCourseClick(
+            @Valid @RequestBody CourseClickLogRequest req,
+            @AuthenticationPrincipal String userId
+    ) {
+        // 이벤트 발행만 하고 즉시 204 반환
+        // 실제 DB 저장 + Redis 집계는 리스너가 별도 스레드에서 처리
+        eventPublisher.publishEvent(new CourseClickEvent(
+                userId,
+                req.getCourseId(),
+                req.getPlatform(),
+                req.getSource()
+        ));
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "오늘의 인기 강좌 TOP N 조회",
+            description = "Redis Sorted Set 기반. DB 집계 쿼리 없이 즉시 반환.")
+    @GetMapping("/courses/popular")
+    public ResponseEntity<Map<String, Double>> getPopularCourses(
+            @RequestParam(defaultValue = "10") int limit // 기본 TOP 10
+    ) {
+        String today = LocalDate.now().toString();
+        String key = "popular:courses:" + today;
+
+        // 점수 높은 순으로 limit개 조회 (ZRANGE ... REV WITHSCORES)
+        Set<ZSetOperations.TypedTuple<String>> result =
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, limit - 1);
+
+        // courseId -> 클릭 수 형태의 Map으로 변환 (순서 보장을 위해 LinkedHashMap)
+        Map<String, Double> popular = new LinkedHashMap<>();
+        if (result != null) {
+            result.forEach(tuple -> popular.put(tuple.getValue(), tuple.getScore()));
+        }
+
+        return ResponseEntity.ok(popular);
+    }
+}
+

--- a/src/main/java/com/example/kuriq/dto/analytics/CourseClickLogRequest.java
+++ b/src/main/java/com/example/kuriq/dto/analytics/CourseClickLogRequest.java
@@ -1,0 +1,26 @@
+package com.example.kuriq.dto.analytics;
+
+import com.example.kuriq.entity.analytics.CourseClickLog;
+import com.example.kuriq.entity.roadmap.Platform;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+// 클릭 로그 요청 시 프론트에서 보내는 데이터
+@Getter
+public class CourseClickLogRequest {
+
+    @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotBlank(message = "강좌 ID를 입력해 주세요")
+    private String courseId; // 클릭된 강좌 ID
+
+    @Schema(example = "K_MOOC", description = "K_MOOC / KOCW / LLL_PORTAL / SEOUL_LLL")
+    @NotNull(message = "플랫폼을 입력해 주세요")
+    private Platform platform; // 정의된 값 외 입력 시 Spring이 자동으로 400 반환
+
+    @Schema(example = "roadmap", description = "roadmap / search / dashboard / recommendation / history")
+    @NotNull(message = "클릭 출처를 입력해 주세요")
+    private CourseClickLog.ClickSource source; // 어느 화면에서 클릭했는지
+}
+

--- a/src/main/java/com/example/kuriq/dto/roadmap/response/RoadmapResponse.java
+++ b/src/main/java/com/example/kuriq/dto/roadmap/response/RoadmapResponse.java
@@ -179,16 +179,12 @@ public class RoadmapResponse {
              * Entity → DTO 변환 메서드
              *
              * Course 엔티티를 클라이언트 응답용 DTO로 변환한다.
-             *
-             * 사용처:
-             * - RoadmapItemResponse.from()
-             * - 강좌 목록 API 응답
              */
             public static CourseResponse from(Course course) {
                 return CourseResponse.builder()
                         .id(course.getId())
                         .title(course.getTitle())
-                        .platform(course.getPlatform())
+                        .platform(course.getPlatform().name())
                         .institution(course.getInstitution())
                         .category(course.getCategory())
                         .difficulty(course.getDifficulty())

--- a/src/main/java/com/example/kuriq/entity/analytics/CourseClickLog.java
+++ b/src/main/java/com/example/kuriq/entity/analytics/CourseClickLog.java
@@ -1,0 +1,85 @@
+package com.example.kuriq.entity.analytics;
+
+import com.example.kuriq.entity.roadmap.Platform;
+import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// 사용자가 수강신청 버튼을 클릭할 때마다 기록이 여기 쌓임
+@Entity
+@Table(
+        name = "course_click_logs",
+        indexes = {
+                // 강좌별 + 시간순 조회 ("이 강좌는 언제 많이 클릭됐나?")
+                @Index(name = "idx_clicks_course_time", columnList = "courseId, clickedAt"),
+
+                // 플랫폼별 + 시간순 조회 ("K-MOOC vs KOCW 중 어디가 더 많이 클릭됐나?")
+                @Index(name = "idx_clicks_platform_time", columnList = "platform, clickedAt"),
+
+                // 시간순 전체 조회 ("오늘 클릭 로그 전체 보기")
+                @Index(name = "idx_clicks_time", columnList = "clickedAt")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseClickLog {
+
+    // 로그 ID (auto increment — 로그 테이블은 UUID보다 숫자 PK가 INSERT 성능이 좋음)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 클릭한 사용자 ID (비로그인 사용자는 null)
+    @Column(length = 36)
+    private String userId;
+
+    // 클릭된 강좌 ID
+    @Column(nullable = false, length = 36)
+    private String courseId;
+
+    // 강좌가 속한 플랫폼 (K_MOOC / KOCW / LLL_PORTAL / SEOUL_LLL)
+    // Course.platform과 동일한 enum 사용
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Platform platform;
+
+    // 어느 화면에서 클릭했는지 (roadmap / search / dashboard / recommendation / history)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ClickSource source;
+
+    // 클릭한 시각
+    @Column(nullable = false)
+    private LocalDateTime clickedAt;
+
+    // clickedAt을 DB에 저장하기 직전에 현재 시각으로 자동 세팅
+    @PrePersist
+    private void prePersist() {
+        clickedAt = LocalDateTime.now();
+    }
+
+    // 클릭 로그 생성 메서드(필수값 누락 방지를 위해, 외부에서 new CourseClickLog() 직접 호출 불가하게 함)
+    public static CourseClickLog create(String userId, String courseId,
+                                        Platform platform, ClickSource source) {
+        CourseClickLog log = new CourseClickLog();
+        log.userId = userId;         // 비로그인이면 null
+        log.courseId = courseId;
+        log.platform = platform;
+        log.source = source;
+        return log;
+    }
+
+    // 어느 화면에서 클릭했는지를 나타내는 enum
+    // ERD의 click_source_enum과 동일
+    public enum ClickSource {
+        roadmap,         // 로드맵 상세 화면
+        search,          // 강좌 검색 화면
+        dashboard,       // 주간 학습 대시보드
+        recommendation,  // 큐리 추천 화면
+        history          // 학습 이력 화면
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/roadmap/Course.java
+++ b/src/main/java/com/example/kuriq/entity/roadmap/Course.java
@@ -54,8 +54,9 @@ public class Course {
     private String id;
 
     // 강좌 제공 플랫폼 (K-MOOC, KOCW 등)
-    @Column(nullable = false, length = 50)
-    private String platform;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Platform platform;
 
     // 원본 플랫폼에서의 강좌 ID
     @Column(nullable = false, length = 255)

--- a/src/main/java/com/example/kuriq/entity/roadmap/Platform.java
+++ b/src/main/java/com/example/kuriq/entity/roadmap/Platform.java
@@ -1,0 +1,11 @@
+package com.example.kuriq.entity.roadmap;
+
+// 큐릭이 수집하는 공공 교육 플랫폼 종류
+// ERD의 platform_enum과 동일
+// Course, CourseClickLog 등 플랫폼을 다루는 곳에서 공통으로 사용하기 때문에 별도 파일로 분리했음
+public enum Platform {
+    K_MOOC,     // 한국형 온라인 공개강좌 (K-MOOC)
+    KOCW,       // 대학 공개강의 서비스 (KOCW)
+    LLL_PORTAL, // 온국민평생배움터
+    SEOUL_LLL // 서울시 평생학습포털
+}

--- a/src/main/java/com/example/kuriq/event/CourseClickEvent.java
+++ b/src/main/java/com/example/kuriq/event/CourseClickEvent.java
@@ -1,0 +1,26 @@
+package com.example.kuriq.event;
+
+import com.example.kuriq.entity.analytics.CourseClickLog;
+import com.example.kuriq.entity.roadmap.Platform;
+import lombok.Getter;
+
+// 클릭이 발생했다는 사실을 담는 이벤트 클래스
+// 컨트롤러 -> 이벤트 발행 -> 리스너가 받아서 DB 저장
+// (이벤트 방식을 쓰는 이유: 컨트롤러가 DB 저장 완료를 기다리지 않고 즉시 응답 반환 가능)
+@Getter
+public class CourseClickEvent {
+
+    private final String userId;      // 클릭한 사용자 ID (비로그인이면 null)
+    private final String courseId;    // 클릭된 강좌 ID
+    private final Platform platform;  // 강좌 플랫폼
+    private final CourseClickLog.ClickSource source; // 어느 화면에서 클릭했는지
+
+    public CourseClickEvent(String userId, String courseId,
+                            Platform platform, CourseClickLog.ClickSource source) {
+        this.userId = userId;
+        this.courseId = courseId;
+        this.platform = platform;
+        this.source = source;
+    }
+}
+

--- a/src/main/java/com/example/kuriq/event/CourseClickEventListener.java
+++ b/src/main/java/com/example/kuriq/event/CourseClickEventListener.java
@@ -1,0 +1,70 @@
+package com.example.kuriq.event;
+
+import com.example.kuriq.entity.analytics.CourseClickLog;
+import com.example.kuriq.repository.analytics.CourseClickLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+// CourseClickEvent를 받아서 DB 저장 + Redis 인기 집계를 처리하는 리스너
+// @Async 덕분에 별도 스레드에서 실행됨 → 컨트롤러는 저장 완료를 기다리지 않음
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CourseClickEventListener {
+
+    private final CourseClickLogRepository courseClickLogRepository;
+    private final StringRedisTemplate redisTemplate; // Redis 조작 도구
+
+    @Async          // 별도 스레드에서 실행 (DB/Redis 작업이 느려도 API 응답에 영향 없음)
+    @EventListener  // 이 메서드가 이벤트 수신자임을 Spring에 알림
+    public void handle(CourseClickEvent event) {
+        saveToDb(event);
+        incrementPopularScore(event.getCourseId());
+    }
+
+    // 1. DB에 클릭 로그 저장
+    private void saveToDb(CourseClickEvent event) {
+        try {
+            CourseClickLog log = CourseClickLog.create(
+                    event.getUserId(),
+                    event.getCourseId(),
+                    event.getPlatform(),
+                    event.getSource()
+            );
+            courseClickLogRepository.save(log);
+        } catch (Exception e) {
+            log.error("클릭 로그 DB 저장 실패 - courseId: {}, error: {}",
+                    event.getCourseId(), e.getMessage());
+        }
+    }
+
+    // 2. Redis Sorted Set에 해당 강좌 클릭 수 +1
+    // Key 예시: popular:courses:2026-05-13
+    // → 날짜별로 관리하고 7일 후 자동 삭제
+    private void incrementPopularScore(String courseId) {
+        try {
+            String today = LocalDate.now().toString(); // "2026-05-13"
+            String key = "popular:courses:" + today;
+
+            // courseId의 점수를 1 증가 (없으면 1로 시작)
+            redisTemplate.opsForZSet().incrementScore(key, courseId, 1);
+
+            // 이 key가 처음 만들어질 때(-1)만 TTL 7일 설정
+            // (이미 TTL이 있으면 덮어쓰지 않기 위해 조건 체크)
+            if (redisTemplate.getExpire(key) == -1) {
+                redisTemplate.expire(key, Duration.ofDays(7));
+            }
+        } catch (Exception e) {
+            // Redis 실패해도 DB 저장에는 영향 없음
+            log.error("Redis 인기 집계 실패 - courseId: {}, error: {}",
+                    courseId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/repository/analytics/CourseClickLogRepository.java
+++ b/src/main/java/com/example/kuriq/repository/analytics/CourseClickLogRepository.java
@@ -1,0 +1,8 @@
+package com.example.kuriq.repository.analytics;
+
+import com.example.kuriq.entity.analytics.CourseClickLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 지금은 save()만 쓰지만, 나중에 분석 쿼리가 생기면 여기에 메서드를 추가하면 됨
+public interface CourseClickLogRepository extends JpaRepository<CourseClickLog, Long> {
+}

--- a/src/main/java/com/example/kuriq/service/UserService.java
+++ b/src/main/java/com/example/kuriq/service/UserService.java
@@ -256,7 +256,7 @@ public class UserService {
         return histories.stream().map(h -> {
             Course course   = courseMap.get(h.getCourseId());
             String title    = course != null ? course.getTitle()    : "삭제된 강좌";
-            String platform = course != null ? course.getPlatform() : "-";
+            String platform = course != null ? course.getPlatform().name() : "-"; 
             String category = course != null ? course.getCategory() : "-";
             return LearningHistoryResponse.from(h, title, platform, category);
         }).toList();


### PR DESCRIPTION
## 개요
사용자가 수강 신청 버튼 클릭 시 행동을 기록하고,
클릭 데이터를 기반으로 인기 강좌를 실시간으로 집계하는 기능을 구현했다.

## 구현 내용
- 클릭 발생 시 강좌 ID, 플랫폼, 클릭 출처, 사용자 ID를 DB에 기록
- 비로그인 사용자 클릭도 기록 대상에 포함
- 클릭 즉시 응답 반환, DB 저장은 비동기로 처리
- Redis Sorted Set으로 클릭할 때마다 인기 강좌 점수 +1 누적
- 인기 강좌 TOP N을 DB 집계 쿼리 없이 Redis에서 즉시 반환

## API 추가
- GET /api/v1/analytics/courses/popular