### PR TITLE
feat: AI 노트 기능 및 주간 대시보드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-mustache-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-aarch_64'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -1,5 +1,6 @@
 package com.example.kuriq.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -104,6 +105,43 @@ public class AiClient {
         private String correctAnswer;
     }
 
+    @Getter
+    @Builder
+    public static class ChatAiRequest {
+        @JsonProperty("note_id")
+        private String noteId;
+
+        @JsonProperty("note_content")
+        private String noteContent;
+
+        @JsonProperty("course_metadata")
+        private String courseMetadata;
+
+        @JsonProperty("recent_history")
+        private List<ChatHistoryItem> recentHistory;
+
+        private String message;
+
+        @JsonProperty("user_id")
+        private String userId;
+
+        @Getter
+        @Builder
+        public static class ChatHistoryItem {
+            private String role;
+            private String message;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class ChatAiResponse {
+        private String message;
+
+        @JsonProperty("note_references")
+        private List<String> noteReferences;
+    }
+
     public RoadmapGenerateAiResponse generateRoadmap(RoadmapGenerateAiRequest request) {
         // 1주차 강좌 세팅
         RoadmapGenerateAiResponse.CourseItemDto course1 = new RoadmapGenerateAiResponse.CourseItemDto();
@@ -186,6 +224,16 @@ public class AiClient {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(QuizGradeAiResponse.class)
+                .block(Duration.ofSeconds(10));
+    }
+
+    public ChatAiResponse chat(ChatAiRequest request) {
+        return aiWebClient.post()
+                .uri("/internal/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ChatAiResponse.class)
                 .block(Duration.ofSeconds(10));
     }
 

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -131,6 +131,23 @@ public class AiClient {
         private List<String> noteReferences;
     }
 
+    @Getter
+    @Builder
+    public static class OrganizeAiRequest {
+        private String noteContent;
+        private String courseTitle;
+        private String courseCategory;
+        private String userId;
+    }
+
+    @Getter
+    @Setter
+    public static class OrganizeAiResponse {
+        private List<String> keywords;
+        private String structuredSummary;
+        private List<String> suggestions;
+    }
+
     public RoadmapGenerateAiResponse generateRoadmap(RoadmapGenerateAiRequest request) {
         // 1주차 강좌 세팅
         RoadmapGenerateAiResponse.CourseItemDto course1 = new RoadmapGenerateAiResponse.CourseItemDto();
@@ -224,6 +241,16 @@ public class AiClient {
                 .retrieve()
                 .bodyToMono(ChatAiResponse.class)
                 .block(Duration.ofSeconds(10));
+    }
+
+    public OrganizeAiResponse organize(OrganizeAiRequest request) {
+        return aiWebClient.post()
+                .uri("/internal/ai/organize")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(OrganizeAiResponse.class)
+                .block(Duration.ofSeconds(15));
     }
 
     private QuizGenerateAiResponse.OptionDto createOption(String id, String text) {

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -65,6 +65,10 @@ public class AiClient {
             private String type;
             private String question;
             private List<OptionDto> options;
+            private String correctAnswer;
+            private String explanation;
+            private String noteReference;
+            private String weakTopic;
         }
 
         @Getter
@@ -122,18 +126,30 @@ public class AiClient {
         QuizGenerateAiResponse.OptionDto o3 = createOption("C", "var 키워드 사용");
         QuizGenerateAiResponse.OptionDto o4 = createOption("D", "new 키워드 사용");
         q1.setOptions(List.of(o1, o2, o3, o4));
+        q1.setCorrectAnswer("B");
+        q1.setExplanation("파이썬은 타입 선언 없이 값 할당만으로 변수를 만들 수 있습니다.");
+        q1.setNoteReference("변수의 선언과 할당");
+        q1.setWeakTopic("변수 생성 방식");
 
         QuizGenerateAiResponse.QuestionDto q2 = new QuizGenerateAiResponse.QuestionDto();
         q2.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q2").getBytes(StandardCharsets.UTF_8)).toString());
         q2.setType("TRUE_FALSE");
         q2.setQuestion("파이썬의 인덱스는 1부터 시작한다.");
         q2.setOptions(null);
+        q2.setCorrectAnswer("false");
+        q2.setExplanation("파이썬의 인덱스는 0부터 시작합니다.");
+        q2.setNoteReference("리스트 인덱스");
+        q2.setWeakTopic("인덱스 개념");
 
         QuizGenerateAiResponse.QuestionDto q3 = new QuizGenerateAiResponse.QuestionDto();
         q3.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q3").getBytes(StandardCharsets.UTF_8)).toString());
         q3.setType("SHORT_ANSWER");
         q3.setQuestion("파이썬에서 여러 값을 순서대로 저장하면서 수정도 가능한 자료형은?");
         q3.setOptions(null);
+        q3.setCorrectAnswer("리스트");
+        q3.setExplanation("여러 값을 순서대로 저장하고 수정 가능한 대표 자료형은 리스트입니다.");
+        q3.setNoteReference("자료형 개요");
+        q3.setWeakTopic("자료형 명칭");
 
         response.setQuestions(List.of(q1, q2, q3));
         return response;

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -3,7 +3,9 @@ package com.example.kuriq.client;
 import lombok.*;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 public class AiClient {
@@ -42,6 +44,38 @@ public class AiClient {
     }
 
     // AI 서버 연동 전 임시 응답
+    @Getter
+    @Builder
+    public static class QuizGenerateAiRequest {
+        private String noteId;
+        private List<String> excludeSessionIds;
+        private String userId;
+    }
+
+    @Getter
+    @Setter
+    public static class QuizGenerateAiResponse {
+        private String courseId;
+        private List<QuestionDto> questions;
+
+        @Getter
+        @Setter
+        public static class QuestionDto {
+            private String questionId;
+            private String type;
+            private String question;
+            private List<OptionDto> options;
+        }
+
+        @Getter
+        @Setter
+        public static class OptionDto {
+            private String id;
+            private String text;
+        }
+    }
+
+    // TODO: AI 서버 연동 전 임시 응답
     public RoadmapGenerateAiResponse generateRoadmap(RoadmapGenerateAiRequest request) {
         // 1주차 강좌 세팅
         RoadmapGenerateAiResponse.CourseItemDto course1 = new RoadmapGenerateAiResponse.CourseItemDto();
@@ -73,5 +107,42 @@ public class AiClient {
         response.setWeeklyHours(5);
         response.setWeeks(List.of(week1, week2));
         return response;
+    }
+
+    public QuizGenerateAiResponse generateQuiz(QuizGenerateAiRequest request) {
+        QuizGenerateAiResponse response = new QuizGenerateAiResponse();
+        response.setCourseId(UUID.nameUUIDFromBytes(("quiz-course:" + request.getNoteId()).getBytes(StandardCharsets.UTF_8)).toString());
+
+        QuizGenerateAiResponse.QuestionDto q1 = new QuizGenerateAiResponse.QuestionDto();
+        q1.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q1").getBytes(StandardCharsets.UTF_8)).toString());
+        q1.setType("MULTIPLE_CHOICE");
+        q1.setQuestion("노트에서 정리한 내용 중, 파이썬에서 변수를 생성할 때 필요한 것은?");
+        QuizGenerateAiResponse.OptionDto o1 = createOption("A", "타입 선언 후 값 할당");
+        QuizGenerateAiResponse.OptionDto o2 = createOption("B", "값 할당만으로 생성");
+        QuizGenerateAiResponse.OptionDto o3 = createOption("C", "var 키워드 사용");
+        QuizGenerateAiResponse.OptionDto o4 = createOption("D", "new 키워드 사용");
+        q1.setOptions(List.of(o1, o2, o3, o4));
+
+        QuizGenerateAiResponse.QuestionDto q2 = new QuizGenerateAiResponse.QuestionDto();
+        q2.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q2").getBytes(StandardCharsets.UTF_8)).toString());
+        q2.setType("TRUE_FALSE");
+        q2.setQuestion("파이썬의 인덱스는 1부터 시작한다.");
+        q2.setOptions(null);
+
+        QuizGenerateAiResponse.QuestionDto q3 = new QuizGenerateAiResponse.QuestionDto();
+        q3.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q3").getBytes(StandardCharsets.UTF_8)).toString());
+        q3.setType("SHORT_ANSWER");
+        q3.setQuestion("파이썬에서 여러 값을 순서대로 저장하면서 수정도 가능한 자료형은?");
+        q3.setOptions(null);
+
+        response.setQuestions(List.of(q1, q2, q3));
+        return response;
+    }
+
+    private QuizGenerateAiResponse.OptionDto createOption(String id, String text) {
+        QuizGenerateAiResponse.OptionDto option = new QuizGenerateAiResponse.OptionDto();
+        option.setId(id);
+        option.setText(text);
+        return option;
     }
 }

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -1,14 +1,20 @@
 package com.example.kuriq.client;
 
 import lombok.*;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
 @Component
+@RequiredArgsConstructor
 public class AiClient {
+
+    private final WebClient aiWebClient;
 
     @Getter
     @Builder
@@ -69,6 +75,7 @@ public class AiClient {
             private String explanation;
             private String noteReference;
             private String weakTopic;
+            private List<String> acceptableKeywords;
         }
 
         @Getter
@@ -79,7 +86,24 @@ public class AiClient {
         }
     }
 
-    // TODO: AI 서버 연동 전 임시 응답
+    @Getter
+    @Builder
+    public static class QuizGradeAiRequest {
+        private String question;
+        private String correctAnswer;
+        private List<String> acceptableKeywords;
+        private String userAnswer;
+        private String userId;
+    }
+
+    @Getter
+    @Setter
+    public static class QuizGradeAiResponse {
+        private String result;
+        private String feedback;
+        private String correctAnswer;
+    }
+
     public RoadmapGenerateAiResponse generateRoadmap(RoadmapGenerateAiRequest request) {
         // 1주차 강좌 세팅
         RoadmapGenerateAiResponse.CourseItemDto course1 = new RoadmapGenerateAiResponse.CourseItemDto();
@@ -121,11 +145,12 @@ public class AiClient {
         q1.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q1").getBytes(StandardCharsets.UTF_8)).toString());
         q1.setType("MULTIPLE_CHOICE");
         q1.setQuestion("노트에서 정리한 내용 중, 파이썬에서 변수를 생성할 때 필요한 것은?");
-        QuizGenerateAiResponse.OptionDto o1 = createOption("A", "타입 선언 후 값 할당");
-        QuizGenerateAiResponse.OptionDto o2 = createOption("B", "값 할당만으로 생성");
-        QuizGenerateAiResponse.OptionDto o3 = createOption("C", "var 키워드 사용");
-        QuizGenerateAiResponse.OptionDto o4 = createOption("D", "new 키워드 사용");
-        q1.setOptions(List.of(o1, o2, o3, o4));
+        q1.setOptions(List.of(
+                createOption("A", "타입 선언 후 값 할당"),
+                createOption("B", "값 할당만으로 생성"),
+                createOption("C", "var 키워드 사용"),
+                createOption("D", "new 키워드 사용")
+        ));
         q1.setCorrectAnswer("B");
         q1.setExplanation("파이썬은 타입 선언 없이 값 할당만으로 변수를 만들 수 있습니다.");
         q1.setNoteReference("변수의 선언과 할당");
@@ -135,7 +160,6 @@ public class AiClient {
         q2.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q2").getBytes(StandardCharsets.UTF_8)).toString());
         q2.setType("TRUE_FALSE");
         q2.setQuestion("파이썬의 인덱스는 1부터 시작한다.");
-        q2.setOptions(null);
         q2.setCorrectAnswer("false");
         q2.setExplanation("파이썬의 인덱스는 0부터 시작합니다.");
         q2.setNoteReference("리스트 인덱스");
@@ -145,14 +169,24 @@ public class AiClient {
         q3.setQuestionId(UUID.nameUUIDFromBytes((request.getNoteId() + ":q3").getBytes(StandardCharsets.UTF_8)).toString());
         q3.setType("SHORT_ANSWER");
         q3.setQuestion("파이썬에서 여러 값을 순서대로 저장하면서 수정도 가능한 자료형은?");
-        q3.setOptions(null);
         q3.setCorrectAnswer("리스트");
         q3.setExplanation("여러 값을 순서대로 저장하고 수정 가능한 대표 자료형은 리스트입니다.");
         q3.setNoteReference("자료형 개요");
         q3.setWeakTopic("자료형 명칭");
+        q3.setAcceptableKeywords(List.of("리스트", "list"));
 
         response.setQuestions(List.of(q1, q2, q3));
         return response;
+    }
+
+    public QuizGradeAiResponse gradeShortAnswer(QuizGradeAiRequest request) {
+        return aiWebClient.post()
+                .uri("/internal/ai/quiz/grade")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(QuizGradeAiResponse.class)
+                .block(Duration.ofSeconds(10));
     }
 
     private QuizGenerateAiResponse.OptionDto createOption(String id, String text) {

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -108,21 +108,12 @@ public class AiClient {
     @Getter
     @Builder
     public static class ChatAiRequest {
-        @JsonProperty("note_id")
-        private String noteId;
-
-        @JsonProperty("note_content")
-        private String noteContent;
-
-        @JsonProperty("course_metadata")
-        private String courseMetadata;
-
-        @JsonProperty("recent_history")
-        private List<ChatHistoryItem> recentHistory;
-
         private String message;
-
-        @JsonProperty("user_id")
+        private String noteContent;
+        private String courseTitle;
+        private String courseCategory;
+        private String courseDifficulty;
+        private List<ChatHistoryItem> chatHistory;
         private String userId;
 
         @Getter
@@ -137,8 +128,6 @@ public class AiClient {
     @Setter
     public static class ChatAiResponse {
         private String message;
-
-        @JsonProperty("note_references")
         private List<String> noteReferences;
     }
 

--- a/src/main/java/com/example/kuriq/config/AiClientConfig.java
+++ b/src/main/java/com/example/kuriq/config/AiClientConfig.java
@@ -1,0 +1,33 @@
+package com.example.kuriq.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@RequiredArgsConstructor
+public class AiClientConfig {
+
+    @Bean
+    public WebClient aiWebClient(@Value("${ai.service.base-url:http://ai-service:8000}") String baseUrl,
+                                 @Value("${internal.api-key:${ai.service.internal-key:dev-internal-key}}") String internalKey) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(10))
+                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("X-Internal-Key", internalKey)
+                .clientConnector(new org.springframework.http.client.reactive.ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/config/SecurityConfig.java
+++ b/src/main/java/com/example/kuriq/config/SecurityConfig.java
@@ -59,6 +59,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH,
                                 "/api/v1/notifications/unsubscribe"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/courses/search"
+                        ).permitAll()
                         // Swagger UI 허용
                         .requestMatchers(
                                 "/swagger-ui.html",

--- a/src/main/java/com/example/kuriq/config/TestCourseDataInitializer.java
+++ b/src/main/java/com/example/kuriq/config/TestCourseDataInitializer.java
@@ -1,0 +1,50 @@
+package com.example.kuriq.config;
+
+import com.example.kuriq.entity.roadmap.Course;
+import com.example.kuriq.repository.roadmap.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.math.BigDecimal;
+
+@Configuration
+@RequiredArgsConstructor
+public class TestCourseDataInitializer {
+
+    public static final String TEST_COURSE_ID = "11111111-1111-1111-1111-111111111111";
+
+    private final CourseRepository courseRepository;
+
+    @Bean
+    public CommandLineRunner seedTestCourse() {
+        return args -> {
+            String platform = "kuriq-test";
+            String platformCourseId = "test-python-001";
+
+            if (courseRepository.existsById(TEST_COURSE_ID)
+                    || courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId).isPresent()) {
+                return;
+            }
+
+            Course course = Course.builder()
+                    .id(TEST_COURSE_ID)
+                    .platform(platform)
+                    .platformCourseId(platformCourseId)
+                    .title("모두를 위한 파이썬")
+                    .institution("Kuriq Test Lab")
+                    .category("프로그래밍")
+                    .difficulty("초급")
+                    .durationWeeks(4)
+                    .estimatedHours(BigDecimal.valueOf(12.0))
+                    .hasCertificate(false)
+                    .url("https://example.com/courses/test-python-001")
+                    .description("노트 생성과 퀴즈/채팅 테스트를 위한 임시 파이썬 강좌입니다.")
+                    .isActive(true)
+                    .build();
+
+            courseRepository.save(course);
+        };
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/CourseController.java
+++ b/src/main/java/com/example/kuriq/controller/CourseController.java
@@ -4,9 +4,11 @@ import com.example.kuriq.dto.course.request.CourseSearchRequest;
 import com.example.kuriq.dto.course.response.CourseSearchResponse;
 import com.example.kuriq.service.CourseService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Course", description = "강좌 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/v1/courses")
 @RequiredArgsConstructor
@@ -21,9 +24,13 @@ public class CourseController {
 
     private final CourseService courseService;
 
-    @Operation(summary = "강좌 검색")
+    @Operation(
+            summary = "강좌 검색",
+            description = "검색어, 플랫폼, 난이도, 카테고리, 기간, 수료증 여부, 정렬, 페이징 조건으로 활성 강좌를 검색합니다."
+    )
     @GetMapping("/search")
-    public ResponseEntity<CourseSearchResponse> search(@Valid @ModelAttribute CourseSearchRequest request) {
+    public ResponseEntity<CourseSearchResponse> search(
+            @Valid @ParameterObject @ModelAttribute CourseSearchRequest request) {
         return ResponseEntity.ok(courseService.search(request));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/CourseController.java
+++ b/src/main/java/com/example/kuriq/controller/CourseController.java
@@ -1,0 +1,29 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.course.request.CourseSearchRequest;
+import com.example.kuriq.dto.course.response.CourseSearchResponse;
+import com.example.kuriq.service.CourseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Course", description = "강좌 API")
+@RestController
+@RequestMapping("/api/v1/courses")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @Operation(summary = "강좌 검색")
+    @GetMapping("/search")
+    public ResponseEntity<CourseSearchResponse> search(@Valid @ModelAttribute CourseSearchRequest request) {
+        return ResponseEntity.ok(courseService.search(request));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/DashboardController.java
+++ b/src/main/java/com/example/kuriq/controller/DashboardController.java
@@ -1,0 +1,43 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.dashboard.response.WeeklyDashboardResponse;
+import com.example.kuriq.service.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Dashboard", description = "학습 대시보드 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/v1/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @Operation(
+            summary = "주간 대시보드 조회",
+            description = "특정 로드맵의 주차별 학습 현황을 조회합니다. weekNumber 생략 시 현재 주차를 자동 산정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주간 대시보드 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "로드맵을 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "로드맵 접근 권한 없음")
+    })
+    @GetMapping("/weekly")
+    public ResponseEntity<WeeklyDashboardResponse> getWeekly(
+            @Parameter(description = "로드맵 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam String roadmapId,
+            @Parameter(description = "주차 번호 (생략 시 현재 주차)", example = "3")
+            @RequestParam(required = false) Integer weekNumber,
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(dashboardService.getWeeklyDashboard(roadmapId, weekNumber, userId));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/NoteChatController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteChatController.java
@@ -1,16 +1,25 @@
 package com.example.kuriq.controller;
 
+import com.example.kuriq.dto.chat.request.ChatSendRequest;
 import com.example.kuriq.dto.chat.response.ChatHistoryResponse;
+import com.example.kuriq.dto.chat.response.ChatSendResponse;
 import com.example.kuriq.service.NoteChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,13 +31,16 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/notes/{noteId}/chat")
 @RequiredArgsConstructor
+@Validated
 public class NoteChatController {
+
+    private static final String UUID_PATTERN = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
 
     private final NoteChatService noteChatService;
 
     @Operation(summary = "대화 초기화")
     @DeleteMapping("/history")
-    public ResponseEntity<Map<String, String>> resetHistory(@PathVariable String noteId,
+    public ResponseEntity<Map<String, String>> resetHistory(@PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
                                                             @AuthenticationPrincipal String userId) {
         noteChatService.resetHistory(noteId, userId);
         return ResponseEntity.ok(Map.of("message", "대화가 초기화되었습니다."));
@@ -36,10 +48,18 @@ public class NoteChatController {
 
     @Operation(summary = "대화 이력 조회")
     @GetMapping("/history")
-    public ResponseEntity<ChatHistoryResponse> getHistory(@PathVariable String noteId,
+    public ResponseEntity<ChatHistoryResponse> getHistory(@PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
                                                           @AuthenticationPrincipal String userId,
-                                                          @RequestParam(defaultValue = "0") int page,
-                                                          @RequestParam(defaultValue = "20") int size) {
+                                                          @RequestParam(defaultValue = "0") @Min(0) int page,
+                                                          @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
         return ResponseEntity.ok(noteChatService.getHistory(noteId, userId, page, size));
+    }
+
+    @Operation(summary = "메시지 전송")
+    @PostMapping
+    public ResponseEntity<ChatSendResponse> sendMessage(@PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
+                                                        @AuthenticationPrincipal String userId,
+                                                        @Valid @RequestBody ChatSendRequest request) {
+        return ResponseEntity.ok(noteChatService.sendMessage(noteId, userId, request));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/NoteChatController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteChatController.java
@@ -1,5 +1,6 @@
 package com.example.kuriq.controller;
 
+import com.example.kuriq.dto.chat.response.ChatHistoryResponse;
 import com.example.kuriq.service.NoteChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -8,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
@@ -29,5 +32,14 @@ public class NoteChatController {
                                                             @AuthenticationPrincipal String userId) {
         noteChatService.resetHistory(noteId, userId);
         return ResponseEntity.ok(Map.of("message", "대화가 초기화되었습니다."));
+    }
+
+    @Operation(summary = "대화 이력 조회")
+    @GetMapping("/history")
+    public ResponseEntity<ChatHistoryResponse> getHistory(@PathVariable String noteId,
+                                                          @AuthenticationPrincipal String userId,
+                                                          @RequestParam(defaultValue = "0") int page,
+                                                          @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(noteChatService.getHistory(noteId, userId, page, size));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/NoteChatController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteChatController.java
@@ -5,6 +5,11 @@ import com.example.kuriq.dto.chat.response.ChatHistoryResponse;
 import com.example.kuriq.dto.chat.response.ChatSendResponse;
 import com.example.kuriq.service.NoteChatService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -38,26 +43,58 @@ public class NoteChatController {
 
     private final NoteChatService noteChatService;
 
-    @Operation(summary = "대화 초기화")
+    @Operation(summary = "대화 초기화", description = "해당 노트의 AI 채팅 대화 이력을 모두 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "대화 초기화 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{ \"message\": \"대화가 초기화되었습니다.\" }"))),
+            @ApiResponse(responseCode = "400", description = "noteId 형식 오류")
+    })
     @DeleteMapping("/history")
-    public ResponseEntity<Map<String, String>> resetHistory(@PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
+    public ResponseEntity<Map<String, String>> resetHistory(@Parameter(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+                                                            @PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
                                                             @AuthenticationPrincipal String userId) {
         noteChatService.resetHistory(noteId, userId);
         return ResponseEntity.ok(Map.of("message", "대화가 초기화되었습니다."));
     }
 
-    @Operation(summary = "대화 이력 조회")
+    @Operation(summary = "대화 이력 조회", description = "해당 노트의 AI 채팅 이력을 페이지 단위로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "대화 이력 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "noteId 또는 페이지 파라미터 검증 실패")
+    })
     @GetMapping("/history")
-    public ResponseEntity<ChatHistoryResponse> getHistory(@PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
+    public ResponseEntity<ChatHistoryResponse> getHistory(@Parameter(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+                                                          @PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
                                                           @AuthenticationPrincipal String userId,
-                                                          @RequestParam(defaultValue = "0") @Min(0) int page,
-                                                          @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
+                                                          @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") @Min(0) int page,
+                                                          @Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
         return ResponseEntity.ok(noteChatService.getHistory(noteId, userId, page, size));
     }
 
-    @Operation(summary = "메시지 전송")
+    @Operation(
+            summary = "메시지 전송",
+            description = "사용자 메시지와 최근 대화 이력을 FastAPI /internal/ai/chat으로 전달하고, AI 답변을 저장한 뒤 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "채팅 메시지 전송 요청 예시",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                              "message": "리스트랑 튜플 차이가 뭐야?"
+                            }
+                            """)
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "AI 답변 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 검증 실패"),
+            @ApiResponse(responseCode = "502", description = "AI 채팅 응답 생성 실패")
+    })
     @PostMapping
-    public ResponseEntity<ChatSendResponse> sendMessage(@PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
+    public ResponseEntity<ChatSendResponse> sendMessage(@Parameter(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+                                                        @PathVariable @Pattern(regexp = UUID_PATTERN, message = "noteId는 UUID 형식이어야 합니다") String noteId,
                                                         @AuthenticationPrincipal String userId,
                                                         @Valid @RequestBody ChatSendRequest request) {
         return ResponseEntity.ok(noteChatService.sendMessage(noteId, userId, request));

--- a/src/main/java/com/example/kuriq/controller/NoteChatController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteChatController.java
@@ -1,0 +1,33 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.service.NoteChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Tag(name = "Note Chat", description = "노트 기반 AI 채팅 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/v1/notes/{noteId}/chat")
+@RequiredArgsConstructor
+public class NoteChatController {
+
+    private final NoteChatService noteChatService;
+
+    @Operation(summary = "대화 초기화")
+    @DeleteMapping("/history")
+    public ResponseEntity<Map<String, String>> resetHistory(@PathVariable String noteId,
+                                                            @AuthenticationPrincipal String userId) {
+        noteChatService.resetHistory(noteId, userId);
+        return ResponseEntity.ok(Map.of("message", "대화가 초기화되었습니다."));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/NoteController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteController.java
@@ -40,7 +40,7 @@ public class NoteController {
                     mediaType = "application/json",
                     examples = @ExampleObject(value = """
                             {
-                              "courseId": "550e8400-e29b-41d4-a716-446655440000",
+                              "courseId": "11111111-1111-1111-1111-111111111111",
                               "content": "파이썬 리스트: 순서가 있고 수정 가능한 자료형. append로 값을 추가할 수 있다."
                             }
                             """)

--- a/src/main/java/com/example/kuriq/controller/NoteController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteController.java
@@ -4,6 +4,10 @@ import com.example.kuriq.dto.note.request.NoteCreateRequest;
 import com.example.kuriq.dto.note.response.NoteCreateResponse;
 import com.example.kuriq.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -25,7 +29,28 @@ public class NoteController {
 
     private final NoteService noteService;
 
-    @Operation(summary = "노트 생성")
+    @Operation(
+            summary = "노트 생성",
+            description = "강좌를 기준으로 사용자의 학습 노트를 생성합니다. content는 1~10,000자까지 저장할 수 있습니다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "노트 생성 요청 예시",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                              "courseId": "550e8400-e29b-41d4-a716-446655440000",
+                              "content": "파이썬 리스트: 순서가 있고 수정 가능한 자료형. append로 값을 추가할 수 있다."
+                            }
+                            """)
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "노트 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "입력값 검증 실패"),
+            @ApiResponse(responseCode = "404", description = "강좌를 찾을 수 없음")
+    })
     @PostMapping
     public ResponseEntity<NoteCreateResponse> create(@Valid @RequestBody NoteCreateRequest request,
                                                      @AuthenticationPrincipal String userId) {

--- a/src/main/java/com/example/kuriq/controller/NoteController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteController.java
@@ -1,9 +1,14 @@
 package com.example.kuriq.controller;
 
 import com.example.kuriq.dto.note.request.NoteCreateRequest;
+import com.example.kuriq.dto.note.request.NoteSaveRequest;
+import com.example.kuriq.dto.note.response.AiOrganizeResponse;
 import com.example.kuriq.dto.note.response.NoteCreateResponse;
+import com.example.kuriq.dto.note.response.NoteDetailResponse;
+import com.example.kuriq.dto.note.response.NoteSaveResponse;
 import com.example.kuriq.service.NoteService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,10 +20,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Tag(name = "Note", description = "학습 노트 API")
 @SecurityRequirement(name = "bearerAuth")
@@ -55,5 +59,88 @@ public class NoteController {
     public ResponseEntity<NoteCreateResponse> create(@Valid @RequestBody NoteCreateRequest request,
                                                      @AuthenticationPrincipal String userId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(noteService.create(request, userId));
+    }
+
+    @Operation(
+            summary = "노트 조회 (강좌별)",
+            description = "특정 강좌에 대한 사용자의 학습 노트를 조회합니다. 노트가 없으면 404를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "노트 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "이 강좌의 노트가 아직 없음")
+    })
+    @GetMapping
+    public ResponseEntity<NoteDetailResponse> getByCourse(
+            @Parameter(description = "강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam String courseId,
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(noteService.getNoteByCourseId(courseId, userId));
+    }
+
+    @Operation(
+            summary = "노트 저장 (자동 저장)",
+            description = "학습 노트 내용을 저장합니다. 프론트엔드에서 마지막 입력 후 3초 경과 시 자동 호출됩니다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "노트 저장 요청 예시",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                            {
+                              "content": "## 1강 - 변수와 자료형\n\n파이썬에서 변수는..."
+                            }
+                            """)
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "노트 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "입력값 검증 실패"),
+            @ApiResponse(responseCode = "404", description = "노트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "노트 접근 권한 없음")
+    })
+    @PutMapping("/{noteId}")
+    public ResponseEntity<NoteSaveResponse> save(
+            @Parameter(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String noteId,
+            @Valid @RequestBody NoteSaveRequest request,
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(noteService.saveNote(noteId, request, userId));
+    }
+
+    @Operation(
+            summary = "AI 노트 정리",
+            description = "노트 내용을 AI 마이크로서비스에 전달하여 LLM 분석을 수행합니다. 키워드 추출, 구조화된 요약, 학습 제안을 반환하며 DB에 저장하지 않습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "AI 노트 정리 성공"),
+            @ApiResponse(responseCode = "404", description = "노트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "노트 접근 권한 없음"),
+            @ApiResponse(responseCode = "502", description = "AI 노트 정리 실패")
+    })
+    @PostMapping("/{noteId}/ai-organize")
+    public ResponseEntity<AiOrganizeResponse> aiOrganize(
+            @Parameter(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String noteId,
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(noteService.aiOrganize(noteId, userId));
+    }
+
+    @Operation(
+            summary = "노트 삭제",
+            description = "학습 노트를 삭제합니다. 관련 퀴즈 기록과 AI 채팅 이력도 함께 삭제됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "노트 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "노트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "노트 접근 권한 없음")
+    })
+    @DeleteMapping("/{noteId}")
+    public ResponseEntity<Map<String, String>> delete(
+            @Parameter(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String noteId,
+            @AuthenticationPrincipal String userId) {
+        noteService.deleteNote(noteId, userId);
+        return ResponseEntity.ok(Map.of("message", "노트가 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/NoteController.java
+++ b/src/main/java/com/example/kuriq/controller/NoteController.java
@@ -1,0 +1,34 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.note.request.NoteCreateRequest;
+import com.example.kuriq.dto.note.response.NoteCreateResponse;
+import com.example.kuriq.service.NoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Note", description = "학습 노트 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/v1/notes")
+@RequiredArgsConstructor
+public class NoteController {
+
+    private final NoteService noteService;
+
+    @Operation(summary = "노트 생성")
+    @PostMapping
+    public ResponseEntity<NoteCreateResponse> create(@Valid @RequestBody NoteCreateRequest request,
+                                                     @AuthenticationPrincipal String userId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(noteService.create(request, userId));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/QuizController.java
+++ b/src/main/java/com/example/kuriq/controller/QuizController.java
@@ -1,8 +1,10 @@
 package com.example.kuriq.controller;
 
 import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
+import com.example.kuriq.dto.quiz.request.QuizSubmitRequest;
 import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
+import com.example.kuriq.dto.quiz.response.QuizSubmitResponse;
 import com.example.kuriq.service.QuizService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,5 +45,13 @@ public class QuizController {
                                                        @RequestParam(defaultValue = "0") int page,
                                                        @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(quizService.history(userId, courseId, page, size));
+    }
+
+    @Operation(summary = "퀴즈 제출")
+    @PostMapping("/{quizSessionId}/submit")
+    public ResponseEntity<QuizSubmitResponse> submit(@Valid @RequestBody QuizSubmitRequest request,
+                                                     @AuthenticationPrincipal String userId,
+                                                     @PathVariable String quizSessionId) {
+        return ResponseEntity.ok(quizService.submit(quizSessionId, request, userId));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/QuizController.java
+++ b/src/main/java/com/example/kuriq/controller/QuizController.java
@@ -1,0 +1,34 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
+import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
+import com.example.kuriq.service.QuizService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Quiz", description = "퀴즈 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/v1/quiz")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @Operation(summary = "퀴즈 생성")
+    @PostMapping("/generate")
+    public ResponseEntity<QuizGenerateResponse> generate(@Valid @RequestBody QuizGenerateRequest request,
+                                                         @AuthenticationPrincipal String userId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(quizService.generate(request, userId));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/QuizController.java
+++ b/src/main/java/com/example/kuriq/controller/QuizController.java
@@ -45,8 +45,7 @@ public class QuizController {
             required = true,
             content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
                     {
-                      "noteId": "550e8400-e29b-41d4-a716-446655440000",
-                      "excludeSessionIds": ["660e8400-e29b-41d4-a716-446655440000"]
+                      "noteId": "550e8400-e29b-41d4-a716-446655440000"
                     }
                     """))
     )

--- a/src/main/java/com/example/kuriq/controller/QuizController.java
+++ b/src/main/java/com/example/kuriq/controller/QuizController.java
@@ -2,11 +2,16 @@ package com.example.kuriq.controller;
 
 import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
 import com.example.kuriq.dto.quiz.request.QuizSubmitRequest;
-import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
+import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.response.QuizSubmitResponse;
 import com.example.kuriq.service.QuizService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -15,10 +20,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,27 +36,79 @@ public class QuizController {
 
     private final QuizService quizService;
 
-    @Operation(summary = "퀴즈 생성")
+    @Operation(
+            summary = "퀴즈 생성",
+            description = "노트 ID를 기반으로 AI 퀴즈 세션과 문항을 생성합니다. excludeSessionIds로 이전 세션과의 중복 생성을 줄일 수 있습니다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "퀴즈 생성 요청 예시",
+            required = true,
+            content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "noteId": "550e8400-e29b-41d4-a716-446655440000",
+                      "excludeSessionIds": ["660e8400-e29b-41d4-a716-446655440000"]
+                    }
+                    """))
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "퀴즈 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "요청값 검증 실패")
+    })
     @PostMapping("/generate")
     public ResponseEntity<QuizGenerateResponse> generate(@Valid @RequestBody QuizGenerateRequest request,
                                                          @AuthenticationPrincipal String userId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(quizService.generate(request, userId));
     }
 
-    @Operation(summary = "퀴즈 히스토리 조회")
+    @Operation(
+            summary = "퀴즈 히스토리 조회",
+            description = "사용자의 퀴즈 세션 이력을 최신순으로 조회합니다. courseId를 전달하면 특정 강좌로 필터링합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "퀴즈 이력 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "페이지 파라미터 오류")
+    })
     @GetMapping("/history")
-    public ResponseEntity<QuizHistoryResponse> history(@AuthenticationPrincipal String userId,
-                                                       @RequestParam(required = false) String courseId,
-                                                       @RequestParam(defaultValue = "0") int page,
-                                                       @RequestParam(defaultValue = "10") int size) {
+    public ResponseEntity<QuizHistoryResponse> history(
+            @AuthenticationPrincipal String userId,
+            @Parameter(description = "강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam(required = false) String courseId,
+            @Parameter(description = "페이지 번호", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(quizService.history(userId, courseId, page, size));
     }
 
-    @Operation(summary = "퀴즈 제출")
+    @Operation(
+            summary = "퀴즈 제출",
+            description = "사용자가 제출한 답안을 채점합니다. 객관식/OX는 Spring에서 직접 채점하고, 단답형은 정확 일치와 허용 키워드 검사 후 필요할 때 FastAPI 단답형 채점을 호출합니다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "퀴즈 답안 제출 요청 예시",
+            required = true,
+            content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "answers": [
+                        { "questionId": "770e8400-e29b-41d4-a716-446655440001", "answer": "B" },
+                        { "questionId": "770e8400-e29b-41d4-a716-446655440002", "answer": false },
+                        { "questionId": "770e8400-e29b-41d4-a716-446655440003", "answer": "리스트" }
+                      ]
+                    }
+                    """))
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채점 성공 또는 기존 제출 결과 반환"),
+            @ApiResponse(responseCode = "400", description = "답안 누락/중복/형식 오류"),
+            @ApiResponse(responseCode = "403", description = "퀴즈 세션 접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "퀴즈 세션을 찾을 수 없음")
+    })
     @PostMapping("/{quizSessionId}/submit")
-    public ResponseEntity<QuizSubmitResponse> submit(@Valid @RequestBody QuizSubmitRequest request,
-                                                     @AuthenticationPrincipal String userId,
-                                                     @PathVariable String quizSessionId) {
+    public ResponseEntity<QuizSubmitResponse> submit(
+            @Valid @RequestBody QuizSubmitRequest request,
+            @AuthenticationPrincipal String userId,
+            @Parameter(description = "퀴즈 세션 ID", example = "660e8400-e29b-41d4-a716-446655440000")
+            @PathVariable String quizSessionId) {
         return ResponseEntity.ok(quizService.submit(quizSessionId, request, userId));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/QuizController.java
+++ b/src/main/java/com/example/kuriq/controller/QuizController.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.controller;
 
 import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
+import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
 import com.example.kuriq.service.QuizService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,9 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Quiz", description = "퀴즈 API")
@@ -30,5 +33,14 @@ public class QuizController {
     public ResponseEntity<QuizGenerateResponse> generate(@Valid @RequestBody QuizGenerateRequest request,
                                                          @AuthenticationPrincipal String userId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(quizService.generate(request, userId));
+    }
+
+    @Operation(summary = "퀴즈 히스토리 조회")
+    @GetMapping("/history")
+    public ResponseEntity<QuizHistoryResponse> history(@AuthenticationPrincipal String userId,
+                                                       @RequestParam(required = false) String courseId,
+                                                       @RequestParam(defaultValue = "0") int page,
+                                                       @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(quizService.history(userId, courseId, page, size));
     }
 }

--- a/src/main/java/com/example/kuriq/dto/chat/request/ChatSendRequest.java
+++ b/src/main/java/com/example/kuriq/dto/chat/request/ChatSendRequest.java
@@ -1,0 +1,15 @@
+package com.example.kuriq.dto.chat.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ChatSendRequest {
+
+    @Schema(example = "리스트랑 튜플 차이가 뭐야?")
+    @NotBlank(message = "message를 입력해 주세요")
+    @Size(min = 1, max = 1000, message = "message는 1~1,000자여야 합니다")
+    private String message;
+}

--- a/src/main/java/com/example/kuriq/dto/chat/request/ChatSendRequest.java
+++ b/src/main/java/com/example/kuriq/dto/chat/request/ChatSendRequest.java
@@ -5,10 +5,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
+@Schema(description = "노트 기반 AI 채팅 메시지 전송 요청")
 @Getter
 public class ChatSendRequest {
 
-    @Schema(example = "리스트랑 튜플 차이가 뭐야?")
+    @Schema(description = "사용자 메시지", example = "리스트랑 튜플 차이가 뭐야?")
     @NotBlank(message = "message를 입력해 주세요")
     @Size(min = 1, max = 1000, message = "message는 1~1,000자여야 합니다")
     private String message;

--- a/src/main/java/com/example/kuriq/dto/chat/response/ChatHistoryResponse.java
+++ b/src/main/java/com/example/kuriq/dto/chat/response/ChatHistoryResponse.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.dto.chat.response;
 
 import com.example.kuriq.entity.chat.ChatMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -11,13 +12,20 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "노트 기반 AI 채팅 이력 조회 응답")
 public class ChatHistoryResponse {
 
+    @Schema(description = "채팅 메시지 목록")
     private List<Item> content;
+    @Schema(description = "전체 메시지 수", example = "12")
     private long totalElements;
+    @Schema(description = "전체 페이지 수", example = "1")
     private int totalPages;
+    @Schema(description = "현재 페이지", example = "0")
     private int currentPage;
+    @Schema(description = "페이지 크기", example = "20")
     private int size;
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
     private boolean hasNext;
 
     public static ChatHistoryResponse from(Page<ChatMessage> page) {
@@ -33,11 +41,17 @@ public class ChatHistoryResponse {
 
     @Getter
     @Builder
+    @Schema(description = "채팅 이력 항목")
     public static class Item {
+        @Schema(description = "채팅 메시지 ID", example = "770e8400-e29b-41d4-a716-446655440000")
         private String chatId;
+        @Schema(description = "메시지 역할", example = "user")
         private String role;
+        @Schema(description = "메시지 내용", example = "리스트랑 튜플 차이가 뭐야?")
         private String message;
+        @Schema(description = "AI 답변에 참조된 노트 문장", example = "[\"리스트: 순서 있음, 수정 가능(mutable)\"]")
         private List<String> noteReferences;
+        @Schema(description = "메시지 생성 시각", example = "2026-04-16T14:35:00+09:00")
         private OffsetDateTime timestamp;
 
         public static Item from(ChatMessage message) {

--- a/src/main/java/com/example/kuriq/dto/chat/response/ChatHistoryResponse.java
+++ b/src/main/java/com/example/kuriq/dto/chat/response/ChatHistoryResponse.java
@@ -1,0 +1,53 @@
+package com.example.kuriq.dto.chat.response;
+
+import com.example.kuriq.entity.chat.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatHistoryResponse {
+
+    private List<Item> content;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private int size;
+    private boolean hasNext;
+
+    public static ChatHistoryResponse from(Page<ChatMessage> page) {
+        return ChatHistoryResponse.builder()
+                .content(page.getContent().stream().map(Item::from).toList())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .currentPage(page.getNumber())
+                .size(page.getSize())
+                .hasNext(page.hasNext())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Item {
+        private String chatId;
+        private String role;
+        private String message;
+        private List<String> noteReferences;
+        private OffsetDateTime timestamp;
+
+        public static Item from(ChatMessage message) {
+            return Item.builder()
+                    .chatId(message.getId())
+                    .role(message.getRole())
+                    .message(message.getMessage())
+                    .noteReferences(message.getNoteReferences())
+                    .timestamp(message.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/chat/response/ChatSendResponse.java
+++ b/src/main/java/com/example/kuriq/dto/chat/response/ChatSendResponse.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.dto.chat.response;
 
 import com.example.kuriq.entity.chat.ChatMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,11 +11,21 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "노트 기반 AI 채팅 메시지 전송 응답")
 public class ChatSendResponse {
+    @Schema(description = "채팅 메시지 ID", example = "770e8400-e29b-41d4-a716-446655440000")
     private String chatId;
+
+    @Schema(description = "메시지 역할", example = "assistant")
     private String role;
+
+    @Schema(description = "AI 응답 메시지", example = "노트에 '리스트: 순서 있음, 수정 가능(mutable)'이라고 정리하셨죠! 튜플은 생성 후 수정할 수 없다는 점이 달라요.")
     private String message;
+
+    @Schema(description = "AI 답변에 참조된 노트 문장", example = "[\"리스트: 순서 있음, 수정 가능(mutable)\"]")
     private List<String> noteReferences;
+
+    @Schema(description = "메시지 생성 시각", example = "2026-04-16T14:35:00+09:00")
     private OffsetDateTime timestamp;
 
     public static ChatSendResponse from(ChatMessage message) {

--- a/src/main/java/com/example/kuriq/dto/chat/response/ChatSendResponse.java
+++ b/src/main/java/com/example/kuriq/dto/chat/response/ChatSendResponse.java
@@ -1,0 +1,29 @@
+package com.example.kuriq.dto.chat.response;
+
+import com.example.kuriq.entity.chat.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatSendResponse {
+    private String chatId;
+    private String role;
+    private String message;
+    private List<String> noteReferences;
+    private OffsetDateTime timestamp;
+
+    public static ChatSendResponse from(ChatMessage message) {
+        return ChatSendResponse.builder()
+                .chatId(message.getId())
+                .role(message.getRole())
+                .message(message.getMessage())
+                .noteReferences(message.getNoteReferences())
+                .timestamp(message.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/course/request/CourseSearchRequest.java
+++ b/src/main/java/com/example/kuriq/dto/course/request/CourseSearchRequest.java
@@ -1,5 +1,6 @@
 package com.example.kuriq.dto.course.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Max;
 import lombok.Getter;
@@ -7,19 +8,36 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "강좌 검색 요청 파라미터")
 public class CourseSearchRequest {
+
+    @Schema(description = "검색어. 강좌명, 기관명, 설명에서 검색합니다.", example = "자바")
     private String keyword;
+
+    @Schema(description = "제공 플랫폼", example = "K-MOOC")
     private String platform;
+
+    @Schema(description = "난이도", example = "초급")
     private String difficulty;
+
+    @Schema(description = "카테고리", example = "프로그래밍")
     private String category;
+
+    @Schema(description = "수강 기간 범위. 0-4, 5-8, 9-12, 13+ 또는 숫자 기반 min-max/min+ 형식을 지원합니다.", example = "5-8")
     private String durationRange;
+
+    @Schema(description = "수료증 제공 여부", example = "true")
     private Boolean hasCertificate;
+
+    @Schema(description = "정렬 기준: latest, title, duration, hours", example = "latest", defaultValue = "latest")
     private String sort = "latest";
 
     @Min(0)
+    @Schema(description = "페이지 번호. 0부터 시작합니다.", example = "0", defaultValue = "0", minimum = "0")
     private int page = 0;
 
     @Min(1)
     @Max(100)
+    @Schema(description = "페이지 크기", example = "20", defaultValue = "20", minimum = "1", maximum = "100")
     private int size = 20;
 }

--- a/src/main/java/com/example/kuriq/dto/course/request/CourseSearchRequest.java
+++ b/src/main/java/com/example/kuriq/dto/course/request/CourseSearchRequest.java
@@ -11,10 +11,10 @@ import lombok.Setter;
 @Schema(description = "강좌 검색 요청 파라미터")
 public class CourseSearchRequest {
 
-    @Schema(description = "검색어. 강좌명, 기관명, 설명에서 검색합니다.", example = "자바")
+    @Schema(description = "검색어. 강좌명, 기관명, 설명에서 검색합니다.", example = "파이썬")
     private String keyword;
 
-    @Schema(description = "제공 플랫폼", example = "K-MOOC")
+    @Schema(description = "제공 플랫폼", example = "kuriq-test")
     private String platform;
 
     @Schema(description = "난이도", example = "초급")
@@ -23,10 +23,10 @@ public class CourseSearchRequest {
     @Schema(description = "카테고리", example = "프로그래밍")
     private String category;
 
-    @Schema(description = "수강 기간 범위. 0-4, 5-8, 9-12, 13+ 또는 숫자 기반 min-max/min+ 형식을 지원합니다.", example = "5-8")
+    @Schema(description = "수강 기간 범위. 0-4, 5-8, 9-12, 13+ 또는 숫자 기반 min-max/min+ 형식을 지원합니다.", example = "0-4")
     private String durationRange;
 
-    @Schema(description = "수료증 제공 여부", example = "true")
+    @Schema(description = "수료증 제공 여부", example = "false")
     private Boolean hasCertificate;
 
     @Schema(description = "정렬 기준: latest, title, duration, hours", example = "latest", defaultValue = "latest")

--- a/src/main/java/com/example/kuriq/dto/course/request/CourseSearchRequest.java
+++ b/src/main/java/com/example/kuriq/dto/course/request/CourseSearchRequest.java
@@ -1,0 +1,25 @@
+package com.example.kuriq.dto.course.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CourseSearchRequest {
+    private String keyword;
+    private String platform;
+    private String difficulty;
+    private String category;
+    private String durationRange;
+    private Boolean hasCertificate;
+    private String sort = "latest";
+
+    @Min(0)
+    private int page = 0;
+
+    @Min(1)
+    @Max(100)
+    private int size = 20;
+}

--- a/src/main/java/com/example/kuriq/dto/course/response/CourseResponse.java
+++ b/src/main/java/com/example/kuriq/dto/course/response/CourseResponse.java
@@ -1,0 +1,37 @@
+package com.example.kuriq.dto.course.response;
+
+import com.example.kuriq.entity.roadmap.Course;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class CourseResponse {
+    private String id;
+    private String title;
+    private String platform;
+    private String institution;
+    private String category;
+    private String difficulty;
+    private Integer durationWeeks;
+    private BigDecimal estimatedHours;
+    private Boolean hasCertificate;
+    private String url;
+
+    public static CourseResponse from(Course course) {
+        return CourseResponse.builder()
+                .id(course.getId())
+                .title(course.getTitle())
+                .platform(course.getPlatform())
+                .institution(course.getInstitution())
+                .category(course.getCategory())
+                .difficulty(course.getDifficulty())
+                .durationWeeks(course.getDurationWeeks())
+                .estimatedHours(course.getEstimatedHours())
+                .hasCertificate(course.getHasCertificate())
+                .url(course.getUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/course/response/CourseSearchResponse.java
+++ b/src/main/java/com/example/kuriq/dto/course/response/CourseSearchResponse.java
@@ -1,0 +1,30 @@
+package com.example.kuriq.dto.course.response;
+
+import com.example.kuriq.entity.roadmap.Course;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CourseSearchResponse {
+    private List<CourseResponse> content;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private int size;
+    private boolean hasNext;
+
+    public static CourseSearchResponse from(Page<Course> page) {
+        return CourseSearchResponse.builder()
+                .content(page.getContent().stream().map(CourseResponse::from).toList())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .currentPage(page.getNumber())
+                .size(page.getSize())
+                .hasNext(page.hasNext())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/dashboard/response/WeeklyDashboardResponse.java
+++ b/src/main/java/com/example/kuriq/dto/dashboard/response/WeeklyDashboardResponse.java
@@ -1,0 +1,100 @@
+package com.example.kuriq.dto.dashboard.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "주간 대시보드 응답")
+public class WeeklyDashboardResponse {
+
+    @Schema(description = "로드맵 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    private String roadmapId;
+
+    @Schema(description = "주차 번호", example = "3")
+    private int weekNumber;
+
+    @Schema(description = "주차 제목", example = "데이터 시각화 입문")
+    private String weekTitle;
+
+    @Schema(description = "주차 기간")
+    private DateRange dateRange;
+
+    @Schema(description = "해당 주차 총 강좌 수", example = "4")
+    private int totalCourses;
+
+    @Schema(description = "완료한 강좌 수", example = "2")
+    private int completedCourses;
+
+    @Schema(description = "진행률 (%)", example = "50")
+    private int progressPercent;
+
+    @Schema(description = "남은 학습 시간 (시간)", example = "3.0")
+    private BigDecimal remainingHours;
+
+    @Schema(description = "해당 주차 강좌 목록")
+    private List<CourseItem> courses;
+
+    @Schema(description = "큐릭 메시지")
+    private KuriqMessage kuriqMessage;
+
+    @Getter
+    @Builder
+    public static class DateRange {
+        @Schema(description = "시작일", example = "2026-04-14")
+        private String start;
+
+        @Schema(description = "종료일", example = "2026-04-20")
+        private String end;
+    }
+
+    @Getter
+    @Builder
+    public static class CourseItem {
+        @Schema(description = "로드맵 항목 ID", example = "660e8400-e29b-41d4-a716-446655440000")
+        private String itemId;
+
+        @Schema(description = "강좌 ID", example = "770e8400-e29b-41d4-a716-446655440000")
+        private String courseId;
+
+        @Schema(description = "강좌명", example = "데이터 시각화 with Python")
+        private String title;
+
+        @Schema(description = "플랫폼", example = "K-MOOC")
+        private String platform;
+
+        @Schema(description = "난이도", example = "초급")
+        private String difficulty;
+
+        @Schema(description = "예상 학습 시간 (시간)", example = "3.0")
+        private BigDecimal estimatedHours;
+
+        @Schema(description = "완료 여부", example = "true")
+        private boolean isCompleted;
+
+        @Schema(description = "완료 시각", example = "2026-04-15T14:30:00+09:00")
+        private OffsetDateTime completedAt;
+
+        @Schema(description = "수강 신청 URL", example = "https://...")
+        private String url;
+
+        @Schema(description = "노트 작성 여부", example = "true")
+        private boolean hasNote;
+    }
+
+    @Getter
+    @Builder
+    public static class KuriqMessage {
+        @Schema(description = "표정", example = "wink")
+        private String expression;
+
+        @Schema(description = "응원 메시지", example = "절반 넘었어요! 잘 하고 있어요 🎉")
+        private String text;
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/note/request/NoteCreateRequest.java
+++ b/src/main/java/com/example/kuriq/dto/note/request/NoteCreateRequest.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public class NoteCreateRequest {
 
-    @Schema(description = "노트를 작성할 강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @Schema(description = "노트를 작성할 강좌 ID", example = "11111111-1111-1111-1111-111111111111")
     @NotBlank(message = "courseId를 입력해 주세요")
     @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "courseId는 UUID 형식이어야 합니다")
     private String courseId;

--- a/src/main/java/com/example/kuriq/dto/note/request/NoteCreateRequest.java
+++ b/src/main/java/com/example/kuriq/dto/note/request/NoteCreateRequest.java
@@ -6,15 +6,16 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
+@Schema(description = "학습 노트 생성 요청")
 @Getter
 public class NoteCreateRequest {
 
-    @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    @Schema(description = "노트를 작성할 강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     @NotBlank(message = "courseId를 입력해 주세요")
     @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "courseId는 UUID 형식이어야 합니다")
     private String courseId;
 
-    @Schema(example = "리스트: 순서 있음, 수정 가능(mutable)")
+    @Schema(description = "학습 노트 내용", example = "파이썬 리스트: 순서가 있고 수정 가능한 자료형. append로 값을 추가할 수 있다.")
     @NotBlank(message = "content를 입력해 주세요")
     @Size(min = 1, max = 10000, message = "content는 1~10,000자여야 합니다")
     private String content;

--- a/src/main/java/com/example/kuriq/dto/note/request/NoteCreateRequest.java
+++ b/src/main/java/com/example/kuriq/dto/note/request/NoteCreateRequest.java
@@ -1,0 +1,21 @@
+package com.example.kuriq.dto.note.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class NoteCreateRequest {
+
+    @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotBlank(message = "courseId를 입력해 주세요")
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "courseId는 UUID 형식이어야 합니다")
+    private String courseId;
+
+    @Schema(example = "리스트: 순서 있음, 수정 가능(mutable)")
+    @NotBlank(message = "content를 입력해 주세요")
+    @Size(min = 1, max = 10000, message = "content는 1~10,000자여야 합니다")
+    private String content;
+}

--- a/src/main/java/com/example/kuriq/dto/note/request/NoteSaveRequest.java
+++ b/src/main/java/com/example/kuriq/dto/note/request/NoteSaveRequest.java
@@ -1,0 +1,16 @@
+package com.example.kuriq.dto.note.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Schema(description = "학습 노트 저장 요청")
+@Getter
+public class NoteSaveRequest {
+
+    @Schema(description = "저장할 노트 내용", example = "## 1강 - 변수와 자료형\n\n파이썬에서 변수는...")
+    @NotBlank(message = "content를 입력해 주세요")
+    @Size(min = 1, max = 10000, message = "content는 1~10,000자여야 합니다")
+    private String content;
+}

--- a/src/main/java/com/example/kuriq/dto/note/response/AiOrganizeResponse.java
+++ b/src/main/java/com/example/kuriq/dto/note/response/AiOrganizeResponse.java
@@ -1,0 +1,31 @@
+package com.example.kuriq.dto.note.response;
+
+import com.example.kuriq.client.AiClient;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "AI 노트 정리 응답")
+public class AiOrganizeResponse {
+
+    @Schema(description = "추출된 키워드 목록", example = "[\"변수\", \"자료형\", \"리스트\", \"딕셔너리\", \"반복문\"]")
+    private List<String> keywords;
+
+    @Schema(description = "구조화된 요약 (마크다운 형식)", example = "### 파이썬 기초 문법\n- 변수: 타입 선언 없이 값 할당으로 생성\n...")
+    private String structuredSummary;
+
+    @Schema(description = "학습 제안 목록")
+    private List<String> suggestions;
+
+    public static AiOrganizeResponse from(AiClient.OrganizeAiResponse aiResponse) {
+        return AiOrganizeResponse.builder()
+                .keywords(aiResponse.getKeywords())
+                .structuredSummary(aiResponse.getStructuredSummary())
+                .suggestions(aiResponse.getSuggestions())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/note/response/NoteCreateResponse.java
+++ b/src/main/java/com/example/kuriq/dto/note/response/NoteCreateResponse.java
@@ -1,0 +1,26 @@
+package com.example.kuriq.dto.note.response;
+
+import com.example.kuriq.entity.note.LearningNote;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Builder
+public class NoteCreateResponse {
+    private String noteId;
+    private String courseId;
+    private String content;
+    private OffsetDateTime lastSavedAt;
+
+    public static NoteCreateResponse from(LearningNote note) {
+        return NoteCreateResponse.builder()
+                .noteId(note.getId())
+                .courseId(note.getCourse().getId())
+                .content(note.getContent())
+                .lastSavedAt(note.getLastSavedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/note/response/NoteCreateResponse.java
+++ b/src/main/java/com/example/kuriq/dto/note/response/NoteCreateResponse.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.dto.note.response;
 
 import com.example.kuriq.entity.note.LearningNote;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,10 +10,18 @@ import java.time.ZoneId;
 
 @Getter
 @Builder
+@Schema(description = "학습 노트 생성 응답")
 public class NoteCreateResponse {
+    @Schema(description = "생성된 노트 ID", example = "660e8400-e29b-41d4-a716-446655440000")
     private String noteId;
+
+    @Schema(description = "강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     private String courseId;
+
+    @Schema(description = "저장된 노트 내용", example = "파이썬 리스트: 순서가 있고 수정 가능한 자료형. append로 값을 추가할 수 있다.")
     private String content;
+
+    @Schema(description = "마지막 저장 시각", example = "2026-04-16T10:00:00+09:00")
     private OffsetDateTime lastSavedAt;
 
     public static NoteCreateResponse from(LearningNote note) {

--- a/src/main/java/com/example/kuriq/dto/note/response/NoteDetailResponse.java
+++ b/src/main/java/com/example/kuriq/dto/note/response/NoteDetailResponse.java
@@ -1,0 +1,52 @@
+package com.example.kuriq.dto.note.response;
+
+import com.example.kuriq.entity.note.LearningNote;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Builder
+@Schema(description = "학습 노트 조회 응답")
+public class NoteDetailResponse {
+
+    @Schema(description = "노트 ID", example = "660e8400-e29b-41d4-a716-446655440000")
+    private String noteId;
+
+    @Schema(description = "강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    private String courseId;
+
+    @Schema(description = "강좌명", example = "모두를 위한 파이썬")
+    private String courseTitle;
+
+    @Schema(description = "플랫폼명", example = "K-MOOC")
+    private String platform;
+
+    @Schema(description = "노트 내용", example = "## 1강 - 변수와 자료형\n\n파이썬에서 변수는...")
+    private String content;
+
+    @Schema(description = "글자 수", example = "1247")
+    private int characterCount;
+
+    @Schema(description = "마지막 저장 시각", example = "2026-04-15T14:30:00+09:00")
+    private OffsetDateTime lastSavedAt;
+
+    @Schema(description = "생성 시각", example = "2026-04-10T09:00:00+09:00")
+    private OffsetDateTime createdAt;
+
+    public static NoteDetailResponse from(LearningNote note) {
+        return NoteDetailResponse.builder()
+                .noteId(note.getId())
+                .courseId(note.getCourse().getId())
+                .courseTitle(note.getCourse().getTitle())
+                .platform(note.getCourse().getPlatform())
+                .content(note.getContent())
+                .characterCount(note.getContent().length())
+                .lastSavedAt(note.getLastSavedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime())
+                .createdAt(note.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/note/response/NoteSaveResponse.java
+++ b/src/main/java/com/example/kuriq/dto/note/response/NoteSaveResponse.java
@@ -1,0 +1,32 @@
+package com.example.kuriq.dto.note.response;
+
+import com.example.kuriq.entity.note.LearningNote;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Builder
+@Schema(description = "학습 노트 저장 응답")
+public class NoteSaveResponse {
+
+    @Schema(description = "노트 ID", example = "660e8400-e29b-41d4-a716-446655440000")
+    private String noteId;
+
+    @Schema(description = "마지막 저장 시각", example = "2026-04-16T10:05:00+09:00")
+    private OffsetDateTime lastSavedAt;
+
+    @Schema(description = "글자 수", example = "1350")
+    private int characterCount;
+
+    public static NoteSaveResponse from(LearningNote note) {
+        return NoteSaveResponse.builder()
+                .noteId(note.getId())
+                .lastSavedAt(note.getLastSavedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime())
+                .characterCount(note.getContent().length())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/quiz/request/QuizGenerateRequest.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/request/QuizGenerateRequest.java
@@ -7,14 +7,15 @@ import lombok.Getter;
 
 import java.util.List;
 
+@Schema(description = "퀴즈 생성 요청")
 @Getter
 public class QuizGenerateRequest {
 
-    @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    @Schema(description = "퀴즈를 생성할 기반 노트 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     @NotBlank(message = "noteId를 입력해 주세요")
     @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "noteId는 UUID 형식이어야 합니다")
     private String noteId;
 
-    @Schema(example = "[\"550e8400-e29b-41d4-a716-446655440001\"]")
+    @Schema(description = "중복 방지용 이전 퀴즈 세션 ID 목록", example = "[\"660e8400-e29b-41d4-a716-446655440000\"]")
     private List<@Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "excludeSessionIds는 UUID 형식이어야 합니다") String> excludeSessionIds;
 }

--- a/src/main/java/com/example/kuriq/dto/quiz/request/QuizGenerateRequest.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/request/QuizGenerateRequest.java
@@ -1,0 +1,20 @@
+package com.example.kuriq.dto.quiz.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class QuizGenerateRequest {
+
+    @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotBlank(message = "noteId를 입력해 주세요")
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "noteId는 UUID 형식이어야 합니다")
+    private String noteId;
+
+    @Schema(example = "[\"550e8400-e29b-41d4-a716-446655440001\"]")
+    private List<@Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "excludeSessionIds는 UUID 형식이어야 합니다") String> excludeSessionIds;
+}

--- a/src/main/java/com/example/kuriq/dto/quiz/request/QuizGenerateRequest.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/request/QuizGenerateRequest.java
@@ -16,6 +16,6 @@ public class QuizGenerateRequest {
     @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "noteId는 UUID 형식이어야 합니다")
     private String noteId;
 
-    @Schema(description = "중복 방지용 이전 퀴즈 세션 ID 목록", example = "[\"660e8400-e29b-41d4-a716-446655440000\"]")
+    @Schema(description = "중복 방지용 이전 퀴즈 세션 ID 목록. 테스트 시에는 비워두거나 생략하세요.", example = "[]")
     private List<@Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "excludeSessionIds는 UUID 형식이어야 합니다") String> excludeSessionIds;
 }

--- a/src/main/java/com/example/kuriq/dto/quiz/request/QuizSubmitRequest.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/request/QuizSubmitRequest.java
@@ -10,21 +10,25 @@ import lombok.Getter;
 
 import java.util.List;
 
+@Schema(description = "퀴즈 답안 제출 요청")
 @Getter
 public class QuizSubmitRequest {
 
+    @Schema(description = "제출 답안 목록")
     @Valid
     @NotEmpty(message = "answers를 입력해 주세요")
     private List<@NotNull(message = "answer 항목을 입력해 주세요") @Valid AnswerDto> answers;
 
     @Getter
+    @Schema(description = "문항별 제출 답안")
     public static class AnswerDto {
-        @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+        @Schema(description = "문항 ID", example = "770e8400-e29b-41d4-a716-446655440001")
         @NotNull(message = "questionId를 입력해 주세요")
         @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "questionId는 UUID 형식이어야 합니다")
         private String questionId;
 
         @NotNull(message = "answer를 입력해 주세요")
+        @Schema(description = "문항 유형별 답안. 객관식은 문자열(A/B/C/D), OX는 Boolean, 단답형은 문자열", example = "B")
         private Object answer;
 
         @JsonIgnore

--- a/src/main/java/com/example/kuriq/dto/quiz/request/QuizSubmitRequest.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/request/QuizSubmitRequest.java
@@ -1,0 +1,35 @@
+package com.example.kuriq.dto.quiz.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class QuizSubmitRequest {
+
+    @Valid
+    @NotEmpty(message = "answers를 입력해 주세요")
+    private List<@NotNull(message = "answer 항목을 입력해 주세요") @Valid AnswerDto> answers;
+
+    @Getter
+    public static class AnswerDto {
+        @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+        @NotNull(message = "questionId를 입력해 주세요")
+        @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "questionId는 UUID 형식이어야 합니다")
+        private String questionId;
+
+        @NotNull(message = "answer를 입력해 주세요")
+        private Object answer;
+
+        @JsonIgnore
+        public String normalizedQuestionId() {
+            return questionId;
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizGenerateResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizGenerateResponse.java
@@ -1,5 +1,6 @@
 package com.example.kuriq.dto.quiz.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,25 +8,38 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "퀴즈 생성 응답")
 public class QuizGenerateResponse {
+    @Schema(description = "퀴즈 세션 ID", example = "660e8400-e29b-41d4-a716-446655440000")
     private String quizSessionId;
+    @Schema(description = "강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     private String courseId;
+    @Schema(description = "노트 ID", example = "550e8400-e29b-41d4-a716-446655440001")
     private String noteId;
+    @Schema(description = "생성된 퀴즈 문항 목록")
     private List<QuestionDto> questions;
 
     @Getter
     @Builder
+    @Schema(description = "퀴즈 문항")
     public static class QuestionDto {
+        @Schema(description = "문항 ID", example = "770e8400-e29b-41d4-a716-446655440001")
         private String questionId;
+        @Schema(description = "문항 유형", example = "MULTIPLE_CHOICE")
         private String type;
+        @Schema(description = "문항 내용", example = "노트에서 정리한 내용 중, 파이썬에서 변수를 생성할 때 필요한 것은?")
         private String question;
+        @Schema(description = "객관식 선택지. TRUE_FALSE/SHORT_ANSWER는 null")
         private List<OptionDto> options;
     }
 
     @Getter
     @Builder
+    @Schema(description = "객관식 선택지")
     public static class OptionDto {
+        @Schema(description = "선택지 ID", example = "A")
         private String id;
+        @Schema(description = "선택지 내용", example = "값 할당만으로 생성")
         private String text;
     }
 }

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizGenerateResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizGenerateResponse.java
@@ -1,0 +1,31 @@
+package com.example.kuriq.dto.quiz.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class QuizGenerateResponse {
+    private String quizSessionId;
+    private String courseId;
+    private String noteId;
+    private List<QuestionDto> questions;
+
+    @Getter
+    @Builder
+    public static class QuestionDto {
+        private String questionId;
+        private String type;
+        private String question;
+        private List<OptionDto> options;
+    }
+
+    @Getter
+    @Builder
+    public static class OptionDto {
+        private String id;
+        private String text;
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizHistoryResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizHistoryResponse.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.dto.quiz.response;
 
 import com.example.kuriq.entity.quiz.QuizSession;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -11,12 +12,19 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "퀴즈 이력 조회 응답")
 public class QuizHistoryResponse {
+    @Schema(description = "퀴즈 이력 목록")
     private List<Item> content;
+    @Schema(description = "전체 이력 수", example = "12")
     private long totalElements;
+    @Schema(description = "전체 페이지 수", example = "2")
     private int totalPages;
+    @Schema(description = "현재 페이지", example = "0")
     private int currentPage;
+    @Schema(description = "페이지 크기", example = "10")
     private int size;
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
     private boolean hasNext;
 
     public static QuizHistoryResponse from(Page<Item> page) {
@@ -32,13 +40,21 @@ public class QuizHistoryResponse {
 
     @Getter
     @Builder
+    @Schema(description = "퀴즈 이력 항목")
     public static class Item {
+        @Schema(description = "퀴즈 세션 ID", example = "660e8400-e29b-41d4-a716-446655440000")
         private String quizSessionId;
+        @Schema(description = "강좌 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         private String courseId;
+        @Schema(description = "강좌 제목", example = "모두를 위한 파이썬")
         private String courseTitle;
+        @Schema(description = "점수 비율", example = "80")
         private int scorePercent;
+        @Schema(description = "정답 수", example = "4")
         private int correctCount;
+        @Schema(description = "전체 문항 수", example = "5")
         private int totalQuestions;
+        @Schema(description = "퀴즈 생성 시각", example = "2026-04-15T14:00:00+09:00")
         private OffsetDateTime createdAt;
 
         public static Item from(QuizSession session, String courseTitle) {

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizHistoryResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizHistoryResponse.java
@@ -1,0 +1,63 @@
+package com.example.kuriq.dto.quiz.response;
+
+import com.example.kuriq.entity.quiz.QuizSession;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Getter
+@Builder
+public class QuizHistoryResponse {
+    private List<Item> content;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private int size;
+    private boolean hasNext;
+
+    public static QuizHistoryResponse from(Page<Item> page) {
+        return QuizHistoryResponse.builder()
+                .content(page.getContent())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .currentPage(page.getNumber())
+                .size(page.getSize())
+                .hasNext(page.hasNext())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Item {
+        private String quizSessionId;
+        private String courseId;
+        private String courseTitle;
+        private int scorePercent;
+        private int correctCount;
+        private int totalQuestions;
+        private OffsetDateTime createdAt;
+
+        public static Item from(QuizSession session, String courseTitle) {
+            int totalQuestions = session.getTotalQuestions() == null ? 0 : session.getTotalQuestions();
+            int correctCount = session.getCorrectCount() == null ? 0 : session.getCorrectCount();
+            int scorePercent = totalQuestions <= 0 ? 0 : (correctCount * 100) / totalQuestions;
+            OffsetDateTime createdAt = session.getCreatedAt()
+                    .atZone(ZoneId.of("Asia/Seoul"))
+                    .toOffsetDateTime();
+
+            return Item.builder()
+                    .quizSessionId(session.getId())
+                    .courseId(session.getCourseId())
+                    .courseTitle(courseTitle)
+                    .scorePercent(scorePercent)
+                    .correctCount(correctCount)
+                    .totalQuestions(totalQuestions)
+                    .createdAt(createdAt)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizSubmitResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizSubmitResponse.java
@@ -1,5 +1,6 @@
 package com.example.kuriq.dto.quiz.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.AllArgsConstructor;
@@ -10,13 +11,21 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "퀴즈 답안 제출 응답")
 public class QuizSubmitResponse {
+    @Schema(description = "퀴즈 세션 ID", example = "660e8400-e29b-41d4-a716-446655440000")
     private String quizSessionId;
+    @Schema(description = "전체 문항 수", example = "5")
     private Integer totalQuestions;
+    @Schema(description = "정답 수", example = "4")
     private Integer correctCount;
+    @Schema(description = "점수 비율", example = "80")
     private Integer scorePercent;
+    @Schema(description = "문항별 채점 결과")
     private List<ResultDto> results;
+    @Schema(description = "전체 결과에 대한 큐리 메시지", example = "5문제 중 4개를 맞혔어요! '자료형 명칭' 부분을 노트에서 한 번 더 확인해 보세요.")
     private String quriMessage;
+    @Schema(description = "취약 주제 목록", example = "[\"자료형 명칭\"]")
     private List<String> weakTopics;
 
     @Getter
@@ -24,16 +33,27 @@ public class QuizSubmitResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(description = "문항별 채점 결과")
     public static class ResultDto {
+        @Schema(description = "문항 ID", example = "770e8400-e29b-41d4-a716-446655440003")
         private String questionId;
+        @Schema(description = "문항 유형", example = "SHORT_ANSWER")
         private String type;
+        @Schema(description = "정답 여부. PARTIAL/GRADING_FAILED는 false", example = "false")
         private Boolean isCorrect;
+        @Schema(description = "단답형 채점 결과", example = "PARTIAL")
         private String result;
+        @Schema(description = "사용자 답안", example = "리스트(list)")
         private Object userAnswer;
+        @Schema(description = "정답", example = "리스트")
         private Object correctAnswer;
+        @Schema(description = "해설", example = "여러 값을 순서대로 저장하고 수정 가능한 대표 자료형은 리스트입니다.")
         private String explanation;
+        @Schema(description = "단답형 PARTIAL/WRONG/GRADING_FAILED 피드백", example = "거의 맞았어요! 정확한 명칭은 리스트입니다.")
         private String feedback;
+        @Schema(description = "노트 참조 문장", example = "리스트: 순서 있음, 수정 가능(mutable)")
         private String noteReference;
+        @Schema(description = "취약 주제", example = "자료형 명칭")
         private String weakTopic;
     }
 }

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizSubmitResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizSubmitResponse.java
@@ -1,0 +1,33 @@
+package com.example.kuriq.dto.quiz.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class QuizSubmitResponse {
+    private String quizSessionId;
+    private Integer totalQuestions;
+    private Integer correctCount;
+    private Integer scorePercent;
+    private List<ResultDto> results;
+    private String quriMessage;
+    private List<String> weakTopics;
+
+    @Getter
+    @Builder
+    public static class ResultDto {
+        private String questionId;
+        private String type;
+        private Boolean isCorrect;
+        private String result;
+        private Object userAnswer;
+        private String correctAnswer;
+        private String explanation;
+        private String feedback;
+        private String noteReference;
+        private String weakTopic;
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/quiz/response/QuizSubmitResponse.java
+++ b/src/main/java/com/example/kuriq/dto/quiz/response/QuizSubmitResponse.java
@@ -2,6 +2,9 @@ package com.example.kuriq.dto.quiz.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -17,6 +20,9 @@ public class QuizSubmitResponse {
     private List<String> weakTopics;
 
     @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Builder
     public static class ResultDto {
         private String questionId;
@@ -24,7 +30,7 @@ public class QuizSubmitResponse {
         private Boolean isCorrect;
         private String result;
         private Object userAnswer;
-        private String correctAnswer;
+        private Object correctAnswer;
         private String explanation;
         private String feedback;
         private String noteReference;

--- a/src/main/java/com/example/kuriq/entity/chat/ChatMessage.java
+++ b/src/main/java/com/example/kuriq/entity/chat/ChatMessage.java
@@ -1,0 +1,55 @@
+package com.example.kuriq.entity.chat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "note_chat_messages")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessage {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    @Column(nullable = false, length = 36)
+    private String noteId;
+
+    @Column(nullable = false, length = 20)
+    private String role;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Convert(converter = JsonStringListConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private List<String> noteReferences;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/chat/JsonStringListConverter.java
+++ b/src/main/java/com/example/kuriq/entity/chat/JsonStringListConverter.java
@@ -1,0 +1,35 @@
+package com.example.kuriq.entity.chat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class JsonStringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return attribute == null ? null : OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to serialize list", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return dbData == null || dbData.isBlank()
+                    ? Collections.emptyList()
+                    : OBJECT_MAPPER.readValue(dbData, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to deserialize list", e);
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/note/LearningNote.java
+++ b/src/main/java/com/example/kuriq/entity/note/LearningNote.java
@@ -59,4 +59,8 @@ public class LearningNote {
     private void preUpdate() {
         lastSavedAt = LocalDateTime.now();
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/example/kuriq/entity/note/LearningNote.java
+++ b/src/main/java/com/example/kuriq/entity/note/LearningNote.java
@@ -1,0 +1,62 @@
+package com.example.kuriq.entity.note;
+
+import com.example.kuriq.entity.roadmap.Course;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "learning_notes")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LearningNote {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime lastSavedAt;
+
+    @PrePersist
+    private void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        lastSavedAt = now;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        lastSavedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/JsonStringListConverter.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/JsonStringListConverter.java
@@ -1,0 +1,33 @@
+package com.example.kuriq.entity.quiz;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class JsonStringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return attribute == null ? null : OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to serialize list", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return dbData == null || dbData.isBlank() ? Collections.emptyList() : OBJECT_MAPPER.readValue(dbData, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to deserialize list", e);
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizOption.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizOption.java
@@ -1,0 +1,32 @@
+package com.example.kuriq.entity.quiz;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(name = "quiz_options")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class QuizOption {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_question_id", nullable = false)
+    private QuizQuestion quizQuestion;
+
+    @Column(nullable = false, length = 10)
+    private String optionId;
+
+    @Column(nullable = false)
+    private Integer orderIndex;
+
+    @Column(nullable = false, length = 500)
+    private String text;
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizQuestion.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizQuestion.java
@@ -1,0 +1,41 @@
+package com.example.kuriq.entity.quiz;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "quiz_questions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class QuizQuestion {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_session_id", nullable = false)
+    private QuizSession quizSession;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private QuizQuestionType type;
+
+    @Column(nullable = false)
+    private Integer orderIndex;
+
+    @Column(nullable = false, length = 1000)
+    private String question;
+
+    @OneToMany(mappedBy = "quizQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("orderIndex ASC")
+    @Builder.Default
+    private List<QuizOption> options = new ArrayList<>();
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizQuestion.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizQuestion.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Entity
 @Table(name = "quiz_questions")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
@@ -46,8 +47,15 @@ public class QuizQuestion {
     @Column(length = 500)
     private String weakTopic;
 
+    @Convert(converter = JsonStringListConverter.class)
+    @Column(length = 2000)
+    private List<String> acceptableKeywords;
+
     @OneToMany(mappedBy = "quizQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     @Builder.Default
     private List<QuizOption> options = new ArrayList<>();
+
+    public void setCorrectAnswer(String correctAnswer) { this.correctAnswer = correctAnswer; }
+    public void setOptions(List<QuizOption> options) { this.options = options; }
 }

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizQuestion.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizQuestion.java
@@ -34,6 +34,18 @@ public class QuizQuestion {
     @Column(nullable = false, length = 1000)
     private String question;
 
+    @Column(length = 1000)
+    private String correctAnswer;
+
+    @Column(length = 2000)
+    private String explanation;
+
+    @Column(length = 500)
+    private String noteReference;
+
+    @Column(length = 500)
+    private String weakTopic;
+
     @OneToMany(mappedBy = "quizQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     @Builder.Default

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizQuestionType.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizQuestionType.java
@@ -1,0 +1,7 @@
+package com.example.kuriq.entity.quiz;
+
+public enum QuizQuestionType {
+    MULTIPLE_CHOICE,
+    TRUE_FALSE,
+    SHORT_ANSWER
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizResult.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizResult.java
@@ -1,0 +1,39 @@
+package com.example.kuriq.entity.quiz;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_results")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class QuizResult {
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+    @Column(name = "session_id", nullable = false, length = 36, unique = true)
+    private String sessionId;
+    @Column(nullable = false, length = 36)
+    private String userId;
+    @Column(nullable = false)
+    private Integer totalQuestions;
+    @Column(nullable = false)
+    private Integer correctCount;
+    @Column(nullable = false)
+    private Integer scorePercent;
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String answersJson;
+    @Column(columnDefinition = "TEXT")
+    private String weakTopicsJson;
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void prePersist() { createdAt = LocalDateTime.now(); }
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizSession.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizSession.java
@@ -37,6 +37,12 @@ public class QuizSession {
     @Column(nullable = false)
     private Integer totalQuestions;
 
+    @Column
+    private Integer submittedCorrectCount;
+
+    @Column
+    private LocalDateTime submittedAt;
+
     @OneToMany(mappedBy = "quizSession", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     @Builder.Default
@@ -51,5 +57,11 @@ public class QuizSession {
             correctCount = 0;
         }
         createdAt = LocalDateTime.now();
+    }
+
+    public void submitScore(Integer correctCount) {
+        this.correctCount = correctCount;
+        this.submittedCorrectCount = correctCount;
+        this.submittedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizSession.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizSession.java
@@ -1,0 +1,45 @@
+package com.example.kuriq.entity.quiz;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "quiz_sessions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class QuizSession {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    @Column(nullable = false, length = 36)
+    private String courseId;
+
+    @Column(nullable = false, length = 36)
+    private String noteId;
+
+    @OneToMany(mappedBy = "quizSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("orderIndex ASC")
+    @Builder.Default
+    private List<QuizQuestion> questions = new ArrayList<>();
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/quiz/QuizSession.java
+++ b/src/main/java/com/example/kuriq/entity/quiz/QuizSession.java
@@ -30,6 +30,13 @@ public class QuizSession {
     @Column(nullable = false, length = 36)
     private String noteId;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer correctCount = 0;
+
+    @Column(nullable = false)
+    private Integer totalQuestions;
+
     @OneToMany(mappedBy = "quizSession", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     @Builder.Default
@@ -40,6 +47,9 @@ public class QuizSession {
 
     @PrePersist
     private void prePersist() {
+        if (correctCount == null) {
+            correctCount = 0;
+        }
         createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/kuriq/exception/ApiException.java
+++ b/src/main/java/com/example/kuriq/exception/ApiException.java
@@ -1,0 +1,16 @@
+package com.example.kuriq.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiException extends RuntimeException {
+    private final String error;
+    private final HttpStatus status;
+
+    public ApiException(String error, String message, HttpStatus status) {
+        super(message);
+        this.error = error;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/kuriq/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kuriq/exception/GlobalExceptionHandler.java
@@ -21,21 +21,21 @@ public class GlobalExceptionHandler {
                 .map(FieldError::getDefaultMessage)
                 .collect(Collectors.joining(", "));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", message));
+                .body(Map.of("error", "INVALID_INPUT", "message", message));
     }
 
     // 이메일/비밀번호 불일치, 중복 이메일 등
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", e.getMessage()));
+                .body(Map.of("error", "INVALID_INPUT", "message", e.getMessage()));
     }
 
     // 로그인 잠금 등
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException e) {
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .body(Map.of("message", e.getMessage()));
+                .body(Map.of("error", "ILLEGAL_STATE", "message", e.getMessage()));
     }
 
     // DB 제약조건 위반 에러 처리 -> 이미 softDelete된 이메일로 회원가입 시 409가 아닌 500 에러 던지는 문제 해결
@@ -43,5 +43,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleDataIntegrity(DataIntegrityViolationException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(Map.of("message", "이미 사용 중인 이메일입니다."));
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<Map<String, String>> handleApi(ApiException e) {
+        return ResponseEntity.status(e.getStatus())
+                .body(Map.of("error", e.getError(), "message", e.getMessage()));
     }
 }

--- a/src/main/java/com/example/kuriq/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/kuriq/repository/chat/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package com.example.kuriq.repository.chat;
+
+import com.example.kuriq.entity.chat.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, String> {
+
+    void deleteByUserIdAndNoteId(String userId, String noteId);
+}

--- a/src/main/java/com/example/kuriq/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/kuriq/repository/chat/ChatMessageRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, String> {
 
     void deleteByUserIdAndNoteId(String userId, String noteId);
 
     Page<ChatMessage> findByUserIdAndNoteId(String userId, String noteId, Pageable pageable);
+
+    List<ChatMessage> findTop20ByUserIdAndNoteIdOrderByCreatedAtDesc(String userId, String noteId);
 }

--- a/src/main/java/com/example/kuriq/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/kuriq/repository/chat/ChatMessageRepository.java
@@ -1,9 +1,13 @@
 package com.example.kuriq.repository.chat;
 
 import com.example.kuriq.entity.chat.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, String> {
 
     void deleteByUserIdAndNoteId(String userId, String noteId);
+
+    Page<ChatMessage> findByUserIdAndNoteId(String userId, String noteId, Pageable pageable);
 }

--- a/src/main/java/com/example/kuriq/repository/note/LearningNoteRepository.java
+++ b/src/main/java/com/example/kuriq/repository/note/LearningNoteRepository.java
@@ -3,5 +3,9 @@ package com.example.kuriq.repository.note;
 import com.example.kuriq.entity.note.LearningNote;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LearningNoteRepository extends JpaRepository<LearningNote, String> {
+
+    Optional<LearningNote> findByUserIdAndCourseId(String userId, String courseId);
 }

--- a/src/main/java/com/example/kuriq/repository/note/LearningNoteRepository.java
+++ b/src/main/java/com/example/kuriq/repository/note/LearningNoteRepository.java
@@ -1,0 +1,7 @@
+package com.example.kuriq.repository.note;
+
+import com.example.kuriq.entity.note.LearningNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearningNoteRepository extends JpaRepository<LearningNote, String> {
+}

--- a/src/main/java/com/example/kuriq/repository/note/LearningNoteRepository.java
+++ b/src/main/java/com/example/kuriq/repository/note/LearningNoteRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface LearningNoteRepository extends JpaRepository<LearningNote, String> {
 
     Optional<LearningNote> findByUserIdAndCourseId(String userId, String courseId);
+
+    boolean existsByUserIdAndCourseId(String userId, String courseId);
 }

--- a/src/main/java/com/example/kuriq/repository/quiz/QuizResultRepository.java
+++ b/src/main/java/com/example/kuriq/repository/quiz/QuizResultRepository.java
@@ -1,0 +1,11 @@
+package com.example.kuriq.repository.quiz;
+
+import com.example.kuriq.entity.quiz.QuizResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QuizResultRepository extends JpaRepository<QuizResult, String> {
+    Optional<QuizResult> findBySessionId(String sessionId);
+    boolean existsBySessionId(String sessionId);
+}

--- a/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
+++ b/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
+import java.util.Optional;
 
 public interface QuizSessionRepository extends JpaRepository<QuizSession, String> {
 
@@ -14,4 +15,8 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, String
     Page<QuizSession> findByUserIdAndCourseId(String userId, String courseId, Pageable pageable);
 
     Page<QuizSession> findByUserId(String userId, Pageable pageable);
+
+    Optional<QuizSession> findByIdAndUserId(String id, String userId);
+
+    boolean existsByIdAndUserId(String id, String userId);
 }

--- a/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
+++ b/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
@@ -1,6 +1,8 @@
 package com.example.kuriq.repository.quiz;
 
 import com.example.kuriq.entity.quiz.QuizSession;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
@@ -8,4 +10,8 @@ import java.util.Collection;
 public interface QuizSessionRepository extends JpaRepository<QuizSession, String> {
 
     long countByIdInAndUserId(Collection<String> ids, String userId);
+
+    Page<QuizSession> findByUserIdAndCourseId(String userId, String courseId, Pageable pageable);
+
+    Page<QuizSession> findByUserId(String userId, Pageable pageable);
 }

--- a/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
+++ b/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
@@ -19,4 +19,6 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, String
     Optional<QuizSession> findByIdAndUserId(String id, String userId);
 
     boolean existsByIdAndUserId(String id, String userId);
+
+    void deleteByUserIdAndNoteId(String userId, String noteId);
 }

--- a/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
+++ b/src/main/java/com/example/kuriq/repository/quiz/QuizSessionRepository.java
@@ -1,0 +1,11 @@
+package com.example.kuriq.repository.quiz;
+
+import com.example.kuriq.entity.quiz.QuizSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+
+public interface QuizSessionRepository extends JpaRepository<QuizSession, String> {
+
+    long countByIdInAndUserId(Collection<String> ids, String userId);
+}

--- a/src/main/java/com/example/kuriq/repository/roadmap/CourseRepository.java
+++ b/src/main/java/com/example/kuriq/repository/roadmap/CourseRepository.java
@@ -2,12 +2,13 @@ package com.example.kuriq.repository.roadmap;
 
 import com.example.kuriq.entity.roadmap.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.Optional;
 
 // Course 테이블 조회/저장 인터페이스
-public interface CourseRepository extends JpaRepository<Course, String> {
+public interface CourseRepository extends JpaRepository<Course, String>, JpaSpecificationExecutor<Course> {
 
     // 플랫폼 + 플랫폼 강좌 ID로 조회 (크롤링 시 중복 방지용)
     Optional<Course> findByPlatformAndPlatformCourseId(String platform, String platformCourseId);

--- a/src/main/java/com/example/kuriq/service/CourseService.java
+++ b/src/main/java/com/example/kuriq/service/CourseService.java
@@ -1,0 +1,77 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.course.request.CourseSearchRequest;
+import com.example.kuriq.dto.course.response.CourseSearchResponse;
+import com.example.kuriq.entity.roadmap.Course;
+import com.example.kuriq.repository.roadmap.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+    public CourseSearchResponse search(CourseSearchRequest request) {
+        Specification<Course> spec = Specification.where((root, query, cb) -> cb.isTrue(root.get("isActive")));
+
+        if (request.getKeyword() != null && !request.getKeyword().isBlank()) {
+            String keyword = "%" + request.getKeyword().toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                    cb.like(cb.lower(root.get("title")), keyword),
+                    cb.like(cb.lower(root.get("institution")), keyword),
+                    cb.like(cb.lower(root.get("description")), keyword)
+            ));
+        }
+        if (request.getPlatform() != null && !request.getPlatform().isBlank()) spec = spec.and(eq("platform", request.getPlatform()));
+        if (request.getDifficulty() != null && !request.getDifficulty().isBlank()) spec = spec.and(eq("difficulty", request.getDifficulty()));
+        if (request.getCategory() != null && !request.getCategory().isBlank()) spec = spec.and(eq("category", request.getCategory()));
+        if (request.getHasCertificate() != null) spec = spec.and(eq("hasCertificate", request.getHasCertificate()));
+        if (request.getDurationRange() != null && !request.getDurationRange().isBlank()) spec = spec.and(durationSpec(request.getDurationRange()));
+
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), sortFor(request.getSort()));
+        Page<Course> page = courseRepository.findAll(spec, pageable);
+        return CourseSearchResponse.from(page);
+    }
+
+    private Specification<Course> eq(String field, Object value) {
+        return (root, query, cb) -> cb.equal(root.get(field), value);
+    }
+
+    private Specification<Course> durationSpec(String range) {
+        String value = range.trim();
+        try {
+            if (value.matches("^\\d+-\\d+$")) {
+                String[] parts = value.split("-");
+                int min = Integer.parseInt(parts[0]);
+                int max = Integer.parseInt(parts[1]);
+                return (root, query, cb) -> cb.between(root.get("durationWeeks"), min, max);
+            }
+            if (value.matches("^\\d+\\+$")) {
+                int min = Integer.parseInt(value.substring(0, value.length() - 1));
+                return (root, query, cb) -> cb.ge(root.get("durationWeeks"), min);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("durationRange 형식이 올바르지 않습니다.");
+        }
+        throw new IllegalArgumentException("durationRange 형식이 올바르지 않습니다.");
+    }
+
+    private Sort sortFor(String sort) {
+        return switch (sort == null ? "latest" : sort) {
+            case "title" -> Sort.by(Sort.Direction.ASC, "title");
+            case "duration" -> Sort.by(Sort.Direction.ASC, "durationWeeks");
+            case "hours" -> Sort.by(Sort.Direction.ASC, "estimatedHours");
+            case "latest" -> Sort.by(Sort.Direction.DESC, "createdAt");
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
+    }
+}

--- a/src/main/java/com/example/kuriq/service/DashboardService.java
+++ b/src/main/java/com/example/kuriq/service/DashboardService.java
@@ -1,0 +1,180 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.dashboard.response.WeeklyDashboardResponse;
+import com.example.kuriq.entity.note.LearningNote;
+import com.example.kuriq.entity.roadmap.Course;
+import com.example.kuriq.entity.roadmap.Roadmap;
+import com.example.kuriq.entity.roadmap.RoadmapItem;
+import com.example.kuriq.entity.roadmap.RoadmapWeek;
+import com.example.kuriq.exception.ApiException;
+import com.example.kuriq.repository.note.LearningNoteRepository;
+import com.example.kuriq.repository.roadmap.RoadmapItemRepository;
+import com.example.kuriq.repository.roadmap.RoadmapRepository;
+import com.example.kuriq.repository.roadmap.RoadmapWeekRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private final RoadmapRepository roadmapRepository;
+    private final RoadmapWeekRepository roadmapWeekRepository;
+    private final RoadmapItemRepository roadmapItemRepository;
+    private final LearningNoteRepository learningNoteRepository;
+
+    public WeeklyDashboardResponse getWeeklyDashboard(String roadmapId, Integer weekNumber, String userId) {
+        Roadmap roadmap = roadmapRepository.findById(roadmapId)
+                .orElseThrow(() -> new ApiException("ROADMAP_NOT_FOUND", "로드맵을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        if (!Objects.equals(roadmap.getUserId(), userId)) {
+            throw new ApiException("FORBIDDEN", "이 로드맵에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        // weekNumber 생략 시 현재 주차 자동 산정
+        int targetWeek = (weekNumber != null) ? weekNumber : roadmap.currentWeek();
+
+        // 주차 메타데이터 조회
+        RoadmapWeek week = roadmapWeekRepository.findByRoadmapIdAndWeekNumber(roadmapId, targetWeek)
+                .orElse(null);
+        String weekTitle = (week != null) ? week.getTitle() : targetWeek + "주차";
+
+        // 해당 주차 강좌 목록 조회
+        List<RoadmapItem> items = roadmapItemRepository.findByRoadmapIdAndWeekNumberOrderByOrderInWeekAsc(roadmapId, targetWeek);
+
+        // 노트 작성 여부 확인을 위한 courseId 집합
+        Set<String> courseIds = items.stream()
+                .map(item -> item.getCourse().getId())
+                .collect(Collectors.toSet());
+
+        // 사용자의 노트 존재 여부 조회
+        Set<String> notedCourseIds = courseIds.stream()
+                .filter(courseId -> learningNoteRepository.existsByUserIdAndCourseId(userId, courseId))
+                .collect(Collectors.toSet());
+
+        // 강좌 항목 DTO 변환
+        List<WeeklyDashboardResponse.CourseItem> courseItems = items.stream()
+                .map(item -> {
+                    Course course = item.getCourse();
+                    return WeeklyDashboardResponse.CourseItem.builder()
+                            .itemId(item.getId())
+                            .courseId(course.getId())
+                            .title(course.getTitle())
+                            .platform(course.getPlatform())
+                            .difficulty(course.getDifficulty())
+                            .estimatedHours(course.getEstimatedHours() != null ? course.getEstimatedHours() : BigDecimal.ZERO)
+                            .isCompleted(Boolean.TRUE.equals(item.getIsCompleted()))
+                            .completedAt(item.getCompletedAt() != null
+                                    ? item.getCompletedAt().atZone(ZoneId.of("Asia/Seoul")).toOffsetDateTime()
+                                    : null)
+                            .url(course.getUrl())
+                            .hasNote(notedCourseIds.contains(course.getId()))
+                            .build();
+                })
+                .toList();
+
+        // 통계 계산
+        int totalCourses = items.size();
+        int completedCourses = (int) items.stream().filter(i -> Boolean.TRUE.equals(i.getIsCompleted())).count();
+        int progressPercent = totalCourses > 0 ? (completedCourses * 100) / totalCourses : 0;
+
+        BigDecimal remainingHours = items.stream()
+                .filter(i -> !Boolean.TRUE.equals(i.getIsCompleted()))
+                .map(i -> i.getCourse().getEstimatedHours() != null ? i.getCourse().getEstimatedHours() : BigDecimal.ZERO)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(1, RoundingMode.HALF_UP);
+
+        // 주차 기간 계산 (로드맵 활성화 기준)
+        WeeklyDashboardResponse.DateRange dateRange = calculateDateRange(roadmap, targetWeek);
+
+        // 큐릭 메시지 생성
+        WeeklyDashboardResponse.KuriqMessage kuriqMessage = generateKuriqMessage(progressPercent, completedCourses, totalCourses);
+
+        return WeeklyDashboardResponse.builder()
+                .roadmapId(roadmapId)
+                .weekNumber(targetWeek)
+                .weekTitle(weekTitle)
+                .dateRange(dateRange)
+                .totalCourses(totalCourses)
+                .completedCourses(completedCourses)
+                .progressPercent(progressPercent)
+                .remainingHours(remainingHours)
+                .courses(courseItems)
+                .kuriqMessage(kuriqMessage)
+                .build();
+    }
+
+    private WeeklyDashboardResponse.DateRange calculateDateRange(Roadmap roadmap, int weekNumber) {
+        LocalDateTime activatedAt = roadmap.getActivatedAt();
+        if (activatedAt == null) {
+            // 활성화 전이면 오늘 기준 주차 계산
+            activatedAt = LocalDateTime.now();
+        }
+
+        LocalDate startDate = activatedAt.toLocalDate().plusWeeks(weekNumber - 1);
+        // 월요일 기준으로 조정
+        startDate = startDate.with(java.time.DayOfWeek.MONDAY);
+        LocalDate endDate = startDate.plusDays(6);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return WeeklyDashboardResponse.DateRange.builder()
+                .start(startDate.format(formatter))
+                .end(endDate.format(formatter))
+                .build();
+    }
+
+    private WeeklyDashboardResponse.KuriqMessage generateKuriqMessage(int progressPercent, int completed, int total) {
+        if (total == 0) {
+            return WeeklyDashboardResponse.KuriqMessage.builder()
+                    .expression("smile")
+                    .text("이번 주차 학습 계획을 확인해 보세요!")
+                    .build();
+        }
+
+        if (progressPercent == 100) {
+            return WeeklyDashboardResponse.KuriqMessage.builder()
+                    .expression("celebrate")
+                    .text("이번 주차 완벽 완료! 정말 대단해요 🎉")
+                    .build();
+        }
+
+        if (progressPercent >= 75) {
+            return WeeklyDashboardResponse.KuriqMessage.builder()
+                    .expression("wink")
+                    .text("거의 다 왔어요! 조금만 더 힘내세요 💪")
+                    .build();
+        }
+
+        if (progressPercent >= 50) {
+            return WeeklyDashboardResponse.KuriqMessage.builder()
+                    .expression("wink")
+                    .text("절반 넘었어요! 잘 하고 있어요 🎉")
+                    .build();
+        }
+
+        if (progressPercent > 0) {
+            return WeeklyDashboardResponse.KuriqMessage.builder()
+                    .expression("smile")
+                    .text("좋은 시작이에요! 꾸준히 계속해 보세요 📚")
+                    .build();
+        }
+
+        return WeeklyDashboardResponse.KuriqMessage.builder()
+                .expression("neutral")
+                .text("새로운 주차가 시작됐어요! 첫걸음을 내딛어 볼까요?")
+                .build();
+    }
+}

--- a/src/main/java/com/example/kuriq/service/NoteChatService.java
+++ b/src/main/java/com/example/kuriq/service/NoteChatService.java
@@ -5,8 +5,10 @@ import com.example.kuriq.dto.chat.request.ChatSendRequest;
 import com.example.kuriq.dto.chat.response.ChatHistoryResponse;
 import com.example.kuriq.dto.chat.response.ChatSendResponse;
 import com.example.kuriq.entity.chat.ChatMessage;
+import com.example.kuriq.entity.note.LearningNote;
 import com.example.kuriq.exception.ApiException;
 import com.example.kuriq.repository.chat.ChatMessageRepository;
+import com.example.kuriq.repository.note.LearningNoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.List;
 
 @Service
@@ -23,6 +26,7 @@ import java.util.List;
 public class NoteChatService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final LearningNoteRepository learningNoteRepository;
     private final AiClient aiClient;
 
     public void resetHistory(String noteId, String userId) {
@@ -41,7 +45,13 @@ public class NoteChatService {
     }
 
     public ChatSendResponse sendMessage(String noteId, String userId, ChatSendRequest request) {
-        List<AiClient.ChatAiRequest.ChatHistoryItem> recentHistory = chatMessageRepository
+        LearningNote note = learningNoteRepository.findById(noteId)
+                .orElseThrow(() -> new ApiException("NOTE_NOT_FOUND", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        if (!Objects.equals(note.getUserId(), userId)) {
+            throw new ApiException("FORBIDDEN", "이 노트에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        List<AiClient.ChatAiRequest.ChatHistoryItem> chatHistory = chatMessageRepository
                 .findTop20ByUserIdAndNoteIdOrderByCreatedAtDesc(userId, noteId)
                 .stream()
                 .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt()))
@@ -62,11 +72,12 @@ public class NoteChatService {
         AiClient.ChatAiResponse aiResponse;
         try {
             aiResponse = aiClient.chat(AiClient.ChatAiRequest.builder()
-                    .noteId(noteId)
-                    .noteContent("")
-                    .courseMetadata("")
-                    .recentHistory(recentHistory)
                     .message(userMessage.getMessage())
+                    .noteContent(note.getContent())
+                    .courseTitle(note.getCourse().getTitle())
+                    .courseCategory(note.getCourse().getCategory() == null ? "기타" : note.getCourse().getCategory())
+                    .courseDifficulty(note.getCourse().getDifficulty() == null ? "입문" : note.getCourse().getDifficulty())
+                    .chatHistory(chatHistory)
                     .userId(userId)
                     .build());
         } catch (Exception e) {

--- a/src/main/java/com/example/kuriq/service/NoteChatService.java
+++ b/src/main/java/com/example/kuriq/service/NoteChatService.java
@@ -1,12 +1,21 @@
 package com.example.kuriq.service;
 
+import com.example.kuriq.client.AiClient;
+import com.example.kuriq.dto.chat.request.ChatSendRequest;
 import com.example.kuriq.dto.chat.response.ChatHistoryResponse;
+import com.example.kuriq.dto.chat.response.ChatSendResponse;
+import com.example.kuriq.entity.chat.ChatMessage;
+import com.example.kuriq.exception.ApiException;
 import com.example.kuriq.repository.chat.ChatMessageRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NoteChatService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final AiClient aiClient;
 
     public void resetHistory(String noteId, String userId) {
         chatMessageRepository.deleteByUserIdAndNoteId(userId, noteId);
@@ -28,5 +38,53 @@ public class NoteChatService {
                         PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"))
                 )
         );
+    }
+
+    public ChatSendResponse sendMessage(String noteId, String userId, ChatSendRequest request) {
+        List<AiClient.ChatAiRequest.ChatHistoryItem> recentHistory = chatMessageRepository
+                .findTop20ByUserIdAndNoteIdOrderByCreatedAtDesc(userId, noteId)
+                .stream()
+                .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt()))
+                .map(chat -> AiClient.ChatAiRequest.ChatHistoryItem.builder()
+                        .role(chat.getRole())
+                        .message(chat.getMessage())
+                        .build())
+                .toList();
+
+        ChatMessage userMessage = chatMessageRepository.save(ChatMessage.builder()
+                .userId(userId)
+                .noteId(noteId)
+                .role("user")
+                .message(request.getMessage())
+                .noteReferences(List.of())
+                .build());
+
+        AiClient.ChatAiResponse aiResponse;
+        try {
+            aiResponse = aiClient.chat(AiClient.ChatAiRequest.builder()
+                    .noteId(noteId)
+                    .noteContent("")
+                    .courseMetadata("")
+                    .recentHistory(recentHistory)
+                    .message(userMessage.getMessage())
+                    .userId(userId)
+                    .build());
+        } catch (Exception e) {
+            throw new ApiException("AI_CHAT_FAILED", "AI 채팅 응답 생성에 실패했습니다.", HttpStatus.BAD_GATEWAY);
+        }
+
+        if (aiResponse == null || aiResponse.getMessage() == null || aiResponse.getMessage().isBlank()) {
+            throw new ApiException("AI_CHAT_FAILED", "AI 채팅 응답 생성에 실패했습니다.", HttpStatus.BAD_GATEWAY);
+        }
+
+        ChatMessage assistantMessage = chatMessageRepository.save(ChatMessage.builder()
+                .userId(userId)
+                .noteId(noteId)
+                .role("assistant")
+                .message(aiResponse.getMessage())
+                .noteReferences(aiResponse.getNoteReferences() == null ? Collections.emptyList() : aiResponse.getNoteReferences())
+                .build());
+
+        return ChatSendResponse.from(assistantMessage);
     }
 }

--- a/src/main/java/com/example/kuriq/service/NoteChatService.java
+++ b/src/main/java/com/example/kuriq/service/NoteChatService.java
@@ -1,0 +1,18 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.repository.chat.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoteChatService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    public void resetHistory(String noteId, String userId) {
+        chatMessageRepository.deleteByUserIdAndNoteId(userId, noteId);
+    }
+}

--- a/src/main/java/com/example/kuriq/service/NoteChatService.java
+++ b/src/main/java/com/example/kuriq/service/NoteChatService.java
@@ -1,7 +1,10 @@
 package com.example.kuriq.service;
 
+import com.example.kuriq.dto.chat.response.ChatHistoryResponse;
 import com.example.kuriq.repository.chat.ChatMessageRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,5 +17,16 @@ public class NoteChatService {
 
     public void resetHistory(String noteId, String userId) {
         chatMessageRepository.deleteByUserIdAndNoteId(userId, noteId);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatHistoryResponse getHistory(String noteId, String userId, int page, int size) {
+        return ChatHistoryResponse.from(
+                chatMessageRepository.findByUserIdAndNoteId(
+                        userId,
+                        noteId,
+                        PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"))
+                )
+        );
     }
 }

--- a/src/main/java/com/example/kuriq/service/NoteService.java
+++ b/src/main/java/com/example/kuriq/service/NoteService.java
@@ -1,16 +1,25 @@
 package com.example.kuriq.service;
 
+import com.example.kuriq.client.AiClient;
 import com.example.kuriq.dto.note.request.NoteCreateRequest;
+import com.example.kuriq.dto.note.request.NoteSaveRequest;
+import com.example.kuriq.dto.note.response.AiOrganizeResponse;
 import com.example.kuriq.dto.note.response.NoteCreateResponse;
+import com.example.kuriq.dto.note.response.NoteDetailResponse;
+import com.example.kuriq.dto.note.response.NoteSaveResponse;
 import com.example.kuriq.entity.note.LearningNote;
 import com.example.kuriq.entity.roadmap.Course;
 import com.example.kuriq.exception.ApiException;
+import com.example.kuriq.repository.chat.ChatMessageRepository;
 import com.example.kuriq.repository.note.LearningNoteRepository;
+import com.example.kuriq.repository.quiz.QuizSessionRepository;
 import com.example.kuriq.repository.roadmap.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +28,9 @@ public class NoteService {
 
     private final LearningNoteRepository learningNoteRepository;
     private final CourseRepository courseRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final AiClient aiClient;
 
     public NoteCreateResponse create(NoteCreateRequest request, String userId) {
         Course course = courseRepository.findById(request.getCourseId())
@@ -31,5 +43,65 @@ public class NoteService {
                 .build());
 
         return NoteCreateResponse.from(note);
+    }
+
+    @Transactional(readOnly = true)
+    public NoteDetailResponse getNoteByCourseId(String courseId, String userId) {
+        LearningNote note = learningNoteRepository.findByUserIdAndCourseId(userId, courseId)
+                .orElseThrow(() -> new ApiException("NOTE_NOT_FOUND", "이 강좌의 노트가 아직 없습니다.", HttpStatus.NOT_FOUND));
+        return NoteDetailResponse.from(note);
+    }
+
+    public NoteSaveResponse saveNote(String noteId, NoteSaveRequest request, String userId) {
+        LearningNote note = learningNoteRepository.findById(noteId)
+                .orElseThrow(() -> new ApiException("NOTE_NOT_FOUND", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        if (!Objects.equals(note.getUserId(), userId)) {
+            throw new ApiException("FORBIDDEN", "이 노트에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        note.updateContent(request.getContent());
+        return NoteSaveResponse.from(note);
+    }
+
+    @Transactional(readOnly = true)
+    public AiOrganizeResponse aiOrganize(String noteId, String userId) {
+        LearningNote note = learningNoteRepository.findById(noteId)
+                .orElseThrow(() -> new ApiException("NOTE_NOT_FOUND", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        if (!Objects.equals(note.getUserId(), userId)) {
+            throw new ApiException("FORBIDDEN", "이 노트에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        AiClient.OrganizeAiRequest request = AiClient.OrganizeAiRequest.builder()
+                .noteContent(note.getContent())
+                .courseTitle(note.getCourse().getTitle())
+                .courseCategory(note.getCourse().getCategory() == null ? "기타" : note.getCourse().getCategory())
+                .userId(userId)
+                .build();
+
+        AiClient.OrganizeAiResponse aiResponse;
+        try {
+            aiResponse = aiClient.organize(request);
+        } catch (Exception e) {
+            throw new ApiException("AI_ORGANIZE_FAILED", "AI 노트 정리에 실패했습니다.", HttpStatus.BAD_GATEWAY);
+        }
+
+        return AiOrganizeResponse.from(aiResponse);
+    }
+
+    public void deleteNote(String noteId, String userId) {
+        LearningNote note = learningNoteRepository.findById(noteId)
+                .orElseThrow(() -> new ApiException("NOTE_NOT_FOUND", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        if (!Objects.equals(note.getUserId(), userId)) {
+            throw new ApiException("FORBIDDEN", "이 노트에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        // 관련 AI 채팅 이력 삭제
+        chatMessageRepository.deleteByUserIdAndNoteId(userId, noteId);
+
+        // 관련 퀴즈 세션 삭제 (QuizQuestion은 cascade로 함께 삭제됨)
+        quizSessionRepository.deleteByUserIdAndNoteId(userId, noteId);
+
+        // 노트 삭제
+        learningNoteRepository.delete(note);
     }
 }

--- a/src/main/java/com/example/kuriq/service/NoteService.java
+++ b/src/main/java/com/example/kuriq/service/NoteService.java
@@ -1,0 +1,35 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.note.request.NoteCreateRequest;
+import com.example.kuriq.dto.note.response.NoteCreateResponse;
+import com.example.kuriq.entity.note.LearningNote;
+import com.example.kuriq.entity.roadmap.Course;
+import com.example.kuriq.exception.ApiException;
+import com.example.kuriq.repository.note.LearningNoteRepository;
+import com.example.kuriq.repository.roadmap.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoteService {
+
+    private final LearningNoteRepository learningNoteRepository;
+    private final CourseRepository courseRepository;
+
+    public NoteCreateResponse create(NoteCreateRequest request, String userId) {
+        Course course = courseRepository.findById(request.getCourseId())
+                .orElseThrow(() -> new ApiException("COURSE_NOT_FOUND", "강좌를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        LearningNote note = learningNoteRepository.save(LearningNote.builder()
+                .userId(userId)
+                .course(course)
+                .content(request.getContent())
+                .build());
+
+        return NoteCreateResponse.from(note);
+    }
+}

--- a/src/main/java/com/example/kuriq/service/QuizService.java
+++ b/src/main/java/com/example/kuriq/service/QuizService.java
@@ -36,23 +36,25 @@ public class QuizService {
     private final QuizSessionRepository quizSessionRepository;
     private final QuizResultRepository quizResultRepository;
     private final CourseRepository courseRepository;
+    private final com.example.kuriq.repository.note.LearningNoteRepository learningNoteRepository;
     private final AiClient aiClient;
     private final ObjectMapper objectMapper;
 
     public QuizGenerateResponse generate(QuizGenerateRequest request, String userId) {
         validateExcludedSessions(request.getExcludeSessionIds(), userId);
 
-        AiClient.QuizGenerateAiResponse aiResponse = aiClient.generateQuiz(
-                AiClient.QuizGenerateAiRequest.builder()
-                        .noteId(request.getNoteId())
-                        .excludeSessionIds(request.getExcludeSessionIds())
-                        .userId(userId)
-                        .build());
+        var note = learningNoteRepository.findById(request.getNoteId())
+                .orElseThrow(() -> new ApiException("NOTE_NOT_FOUND", "노트를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        if (!Objects.equals(note.getUserId(), userId)) {
+            throw new ApiException("FORBIDDEN", "이 노트에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        AiClient.QuizGenerateAiResponse aiResponse = buildQuizResponseFromNote(note);
         validateAiResponse(aiResponse);
 
         QuizSession session = QuizSession.builder()
                 .userId(userId)
-                .courseId(aiResponse.getCourseId())
+                .courseId(note.getCourse().getId())
                 .noteId(request.getNoteId())
                 .totalQuestions(aiResponse.getQuestions().size())
                 .build();
@@ -189,7 +191,118 @@ public class QuizService {
         return response;
     }
 
-    private void validateExcludedSessions(List<String> excludeSessionIds, String userId) {
+    private AiClient.QuizGenerateAiResponse buildQuizResponseFromNote(com.example.kuriq.entity.note.LearningNote note) {
+        AiClient.QuizGenerateAiResponse response = new AiClient.QuizGenerateAiResponse();
+        response.setCourseId(note.getCourse().getId());
+
+        String content = note.getContent() == null ? "" : note.getContent().trim();
+        String topic = extractTopic(content, note.getCourse().getTitle());
+        String detail = extractDetail(content, topic);
+        String noteReference = buildNoteReference(content);
+
+        AiClient.QuizGenerateAiResponse.QuestionDto q1 = new AiClient.QuizGenerateAiResponse.QuestionDto();
+        q1.setQuestionId(java.util.UUID.nameUUIDFromBytes((note.getId() + ":q1").getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString());
+        q1.setType("MULTIPLE_CHOICE");
+        q1.setQuestion("노트에서 정리한 '" + topic + "'의 설명으로 가장 알맞은 것은?");
+        q1.setOptions(List.of(
+                createOption("A", detail),
+                createOption("B", "노트에 적히지 않은 설명"),
+                createOption("C", "정반대의 내용"),
+                createOption("D", "문맥과 무관한 설명")
+        ));
+        q1.setCorrectAnswer("A");
+        q1.setExplanation("노트에 '" + topic + "'를 " + detail + "로 정리하셨습니다.");
+        q1.setNoteReference(noteReference);
+        q1.setWeakTopic(topic);
+
+        AiClient.QuizGenerateAiResponse.QuestionDto q2 = new AiClient.QuizGenerateAiResponse.QuestionDto();
+        q2.setQuestionId(java.util.UUID.nameUUIDFromBytes((note.getId() + ":q2").getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString());
+        q2.setType("TRUE_FALSE");
+        q2.setQuestion("노트에는 '" + topic + "'에 대해 '" + detail + "'라고 정리되어 있다.");
+        q2.setCorrectAnswer("true");
+        q2.setExplanation("노트의 핵심 설명과 일치합니다.");
+        q2.setNoteReference(noteReference);
+        q2.setWeakTopic(topic);
+
+        AiClient.QuizGenerateAiResponse.QuestionDto q3 = new AiClient.QuizGenerateAiResponse.QuestionDto();
+        q3.setQuestionId(java.util.UUID.nameUUIDFromBytes((note.getId() + ":q3").getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString());
+        q3.setType("SHORT_ANSWER");
+        q3.setQuestion("노트에서 핵심 개념으로 언급된 용어는?");
+        q3.setCorrectAnswer(topic);
+        q3.setExplanation("노트의 핵심 개념을 정확히 기억하면 됩니다.");
+        q3.setNoteReference(noteReference);
+        q3.setWeakTopic(topic);
+        q3.setAcceptableKeywords(buildAcceptableKeywords(topic, content));
+
+        response.setQuestions(List.of(q1, q2, q3));
+        return response;
+    }
+
+    private String extractTopic(String content, String courseTitle) {
+        if (content == null || content.isBlank()) {
+            return courseTitle == null || courseTitle.isBlank() ? "핵심 개념" : courseTitle;
+        }
+        String firstLine = content.split("[\\n\\r]")[0].trim();
+        int colonIndex = firstLine.indexOf(':');
+        if (colonIndex > 0) {
+            return firstLine.substring(0, colonIndex).trim();
+        }
+        String[] words = firstLine.split("\\s+");
+        if (words.length >= 2) {
+            return words[0] + " " + words[1];
+        }
+        return firstLine.length() > 12 ? firstLine.substring(0, 12).trim() : firstLine;
+    }
+
+    private String extractDetail(String content, String topic) {
+        if (content == null || content.isBlank()) {
+            return topic + "에 대한 설명";
+        }
+        String firstLine = content.split("[\\n\\r]")[0].trim();
+        int colonIndex = firstLine.indexOf(':');
+        if (colonIndex > 0 && colonIndex + 1 < firstLine.length()) {
+            return firstLine.substring(colonIndex + 1).trim();
+        }
+        return firstLine;
+    }
+
+    private String buildNoteReference(String content) {
+        if (content == null || content.isBlank()) {
+            return "노트 내용";
+        }
+        String firstLine = content.split("[\\n\\r]")[0].trim();
+        return firstLine.length() > 120 ? firstLine.substring(0, 120).trim() : firstLine;
+    }
+
+    private List<String> buildAcceptableKeywords(String topic, String content) {
+        java.util.LinkedHashSet<String> keywords = new java.util.LinkedHashSet<>();
+        if (topic != null && !topic.isBlank()) {
+            keywords.add(topic.trim());
+            for (String word : topic.trim().split("\\s+")) {
+                if (!word.isBlank()) keywords.add(word.trim());
+            }
+        }
+        if (content != null && !content.isBlank()) {
+            String normalized = content.replace(':', ' ').replace('-', ' ');
+            for (String token : normalized.split("\\s+")) {
+                String cleaned = token.replaceAll("[\\[\\]\\(\\)\\{\\},。.!?]", "").trim();
+                if (cleaned.length() >= 2) {
+                    keywords.add(cleaned);
+                }
+            }
+        }
+        return List.copyOf(keywords);
+    }
+
+
+    private AiClient.QuizGenerateAiResponse.OptionDto createOption(String id, String text) {
+        AiClient.QuizGenerateAiResponse.OptionDto option = new AiClient.QuizGenerateAiResponse.OptionDto();
+        option.setId(id);
+        option.setText(text);
+        return option;
+    }
+
+        private void validateExcludedSessions(List<String> excludeSessionIds, String userId) {
         if (excludeSessionIds == null || excludeSessionIds.isEmpty()) {
             return;
         }

--- a/src/main/java/com/example/kuriq/service/QuizService.java
+++ b/src/main/java/com/example/kuriq/service/QuizService.java
@@ -6,12 +6,16 @@ import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
 import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
 import com.example.kuriq.dto.quiz.response.QuizSubmitResponse;
+import com.example.kuriq.entity.quiz.QuizResult;
 import com.example.kuriq.entity.quiz.QuizOption;
 import com.example.kuriq.entity.quiz.QuizQuestion;
 import com.example.kuriq.entity.quiz.QuizQuestionType;
 import com.example.kuriq.entity.quiz.QuizSession;
+import com.example.kuriq.exception.ApiException;
+import com.example.kuriq.repository.quiz.QuizResultRepository;
 import com.example.kuriq.repository.quiz.QuizSessionRepository;
 import com.example.kuriq.repository.roadmap.CourseRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -19,12 +23,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.HttpStatus;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,8 +34,10 @@ import java.util.stream.Collectors;
 public class QuizService {
 
     private final QuizSessionRepository quizSessionRepository;
+    private final QuizResultRepository quizResultRepository;
     private final CourseRepository courseRepository;
     private final AiClient aiClient;
+    private final ObjectMapper objectMapper;
 
     public QuizGenerateResponse generate(QuizGenerateRequest request, String userId) {
         validateExcludedSessions(request.getExcludeSessionIds(), userId);
@@ -65,6 +68,7 @@ public class QuizService {
                     .explanation(q.getExplanation())
                     .noteReference(q.getNoteReference())
                     .weakTopic(q.getWeakTopic())
+                    .acceptableKeywords(q.getAcceptableKeywords())
                     .build();
             if (q.getOptions() != null) {
                 for (int optionIndex = 0; optionIndex < q.getOptions().size(); optionIndex++) {
@@ -119,50 +123,70 @@ public class QuizService {
 
     public QuizSubmitResponse submit(String quizSessionId, QuizSubmitRequest request, String userId) {
         QuizSession session = quizSessionRepository.findById(quizSessionId)
-                .orElseThrow(() -> new IllegalArgumentException("퀴즈 세션을 찾을 수 없습니다"));
+                .orElseThrow(() -> new ApiException("QUIZ_SESSION_NOT_FOUND", "퀴즈를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         if (!Objects.equals(session.getUserId(), userId)) {
-            throw new IllegalArgumentException("퀴즈 세션에 접근 권한이 없습니다");
+            throw new ApiException("FORBIDDEN", "이 퀴즈에 접근할 수 없습니다.", HttpStatus.FORBIDDEN);
         }
+        return quizResultRepository.findBySessionId(quizSessionId)
+                .map(r -> toResponse(r, session))
+                .orElseGet(() -> gradeAndSave(session, request, userId));
+    }
+
+    private QuizSubmitResponse gradeAndSave(QuizSession session, QuizSubmitRequest request, String userId) {
 
         Map<String, QuizQuestion> questionMap = session.getQuestions().stream()
                 .collect(Collectors.toMap(QuizQuestion::getId, q -> q));
+        if (request.getAnswers() == null || request.getAnswers().size() != questionMap.size()) {
+            throw new ApiException("INVALID_INPUT", "모든 문제에 답변해 주세요.", HttpStatus.BAD_REQUEST);
+        }
         Set<String> submittedIds = new HashSet<>();
+        Map<String, Object> answersByQuestionId = new HashMap<>();
         List<QuizSubmitResponse.ResultDto> results = new java.util.ArrayList<>();
         Set<String> weakTopics = new java.util.LinkedHashSet<>();
         int correctCount = 0;
 
         for (QuizSubmitRequest.AnswerDto answerDto : request.getAnswers()) {
             if (!submittedIds.add(answerDto.getQuestionId())) {
-                throw new IllegalArgumentException("중복된 questionId가 있습니다");
+                throw new ApiException("INVALID_INPUT", "모든 문제에 답변해 주세요.", HttpStatus.BAD_REQUEST);
             }
             QuizQuestion question = questionMap.get(answerDto.getQuestionId());
             if (question == null) {
-                throw new IllegalArgumentException("세션에 포함되지 않은 questionId가 있습니다");
+                throw new ApiException("INVALID_INPUT", "모든 문제에 답변해 주세요.", HttpStatus.BAD_REQUEST);
             }
+            answersByQuestionId.put(answerDto.getQuestionId(), answerDto.getAnswer());
+        }
 
-            var evaluated = evaluate(question, answerDto.getAnswer());
+        for (QuizQuestion question : session.getQuestions()) {
+            var evaluated = evaluate(question, answersByQuestionId.get(question.getId()), userId);
             if (Boolean.TRUE.equals(evaluated.getIsCorrect())) correctCount++;
             if (evaluated.getWeakTopic() != null) weakTopics.add(evaluated.getWeakTopic());
             results.add(evaluated);
-        }
-
-        if (submittedIds.size() != questionMap.size()) {
-            throw new IllegalArgumentException("모든 문항의 답안을 제출해 주세요");
         }
 
         session.submitScore(correctCount);
         quizSessionRepository.save(session);
 
         int scorePercent = calculateScorePercent(correctCount, session.getTotalQuestions());
-        return QuizSubmitResponse.builder()
+        var response = QuizSubmitResponse.builder()
                 .quizSessionId(session.getId())
                 .totalQuestions(session.getTotalQuestions())
                 .correctCount(correctCount)
                 .scorePercent(scorePercent)
                 .results(results)
-                .quriMessage(scorePercent >= 80 ? "잘했어요!" : "다시 복습해봐요.")
+                .quriMessage(buildQuriMessage(scorePercent, correctCount, session.getTotalQuestions(), new java.util.ArrayList<>(weakTopics)))
                 .weakTopics(new java.util.ArrayList<>(weakTopics))
                 .build();
+
+        quizResultRepository.save(QuizResult.builder()
+                .sessionId(session.getId())
+                .userId(userId)
+                .totalQuestions(session.getTotalQuestions())
+                .correctCount(correctCount)
+                .scorePercent(scorePercent)
+                .answersJson(writeJson(results))
+                .weakTopicsJson(writeJson(new ArrayList<>(weakTopics)))
+                .build());
+        return response;
     }
 
     private void validateExcludedSessions(List<String> excludeSessionIds, String userId) {
@@ -233,7 +257,7 @@ public class QuizService {
         return Objects.isNull(value) || value.isBlank();
     }
 
-    private QuizSubmitResponse.ResultDto evaluate(QuizQuestion question, Object answer) {
+    private QuizSubmitResponse.ResultDto evaluate(QuizQuestion question, Object answer, String userId) {
         String type = question.getType().name();
         String correct = question.getCorrectAnswer();
         boolean isCorrect;
@@ -242,21 +266,41 @@ public class QuizService {
         String weakTopic = null;
 
         if (question.getType() == QuizQuestionType.MULTIPLE_CHOICE) {
-            if (answer != null && !(answer instanceof String)) throw new IllegalArgumentException("객관식 답안은 문자열이어야 합니다");
+            if (answer != null && !(answer instanceof String)) throw new ApiException("INVALID_INPUT", "모든 문제에 답변해 주세요.", HttpStatus.BAD_REQUEST);
             String user = answer == null ? null : String.valueOf(answer);
             isCorrect = normalize(user).equals(normalize(correct));
         } else if (question.getType() == QuizQuestionType.TRUE_FALSE) {
-            if (answer != null && !(answer instanceof Boolean) && !(answer instanceof String)) throw new IllegalArgumentException("True/False 답안은 boolean 또는 문자열이어야 합니다");
+            if (answer != null && !(answer instanceof Boolean) && !(answer instanceof String)) throw new ApiException("INVALID_INPUT", "모든 문제에 답변해 주세요.", HttpStatus.BAD_REQUEST);
             String user = normalizeBoolean(answer);
             isCorrect = normalize(user).equals(normalizeBoolean(correct));
         } else {
-            if (answer != null && !(answer instanceof String)) throw new IllegalArgumentException("단답형 답안은 문자열이어야 합니다");
+            if (answer != null && !(answer instanceof String)) throw new ApiException("INVALID_INPUT", "모든 문제에 답변해 주세요.", HttpStatus.BAD_REQUEST);
             String user = answer == null ? null : String.valueOf(answer);
-            isCorrect = normalize(user).equalsIgnoreCase(normalize(correct));
-            if (!isCorrect && "배열".equals(normalize(user)) && "리스트".equals(normalize(correct))) {
-                result = "PARTIAL";
-                feedback = "'배열'은 유사한 개념이지만 정답은 '리스트'입니다.";
-                weakTopic = question.getWeakTopic();
+            if (normalize(user).equalsIgnoreCase(normalize(correct))) {
+                isCorrect = true;
+            } else if (matchesKeywords(user, question.getAcceptableKeywords())) {
+                isCorrect = true;
+            } else {
+                try {
+                    var graded = aiClient.gradeShortAnswer(AiClient.QuizGradeAiRequest.builder().question(question.getQuestion()).correctAnswer(question.getCorrectAnswer()).acceptableKeywords(question.getAcceptableKeywords()).userAnswer(user).userId(userId).build());
+                    if (graded == null) {
+                        result = "GRADING_FAILED";
+                        feedback = "채점에 일시적인 문제가 발생했어요. 모범 답안을 확인해 주세요.";
+                    } else {
+                        String aiResult = normalize(graded.getResult()).toUpperCase();
+                        if (Set.of("CORRECT", "PARTIAL", "WRONG").contains(aiResult)) {
+                            result = aiResult;
+                            feedback = graded.getFeedback();
+                        } else {
+                            result = "GRADING_FAILED";
+                            feedback = "채점에 일시적인 문제가 발생했어요. 모범 답안을 확인해 주세요.";
+                        }
+                    }
+                } catch (Exception e) {
+                    result = "GRADING_FAILED";
+                    feedback = "채점에 일시적인 문제가 발생했어요. 모범 답안을 확인해 주세요.";
+                }
+                isCorrect = "CORRECT".equals(result);
             }
         }
 
@@ -269,7 +313,7 @@ public class QuizService {
                 .isCorrect(isCorrect)
                 .result(result)
                 .userAnswer(answer)
-                .correctAnswer(correct)
+                .correctAnswer(formatCorrectAnswer(question))
                 .explanation(question.getExplanation())
                 .feedback(feedback)
                 .noteReference(question.getNoteReference())
@@ -288,5 +332,63 @@ public class QuizService {
 
     private int calculateScorePercent(int correctCount, Integer totalQuestions) {
         return totalQuestions == null || totalQuestions == 0 ? 0 : (correctCount * 100) / totalQuestions;
+    }
+
+    private Object formatCorrectAnswer(QuizQuestion question) {
+        if (question.getType() == QuizQuestionType.TRUE_FALSE) {
+            return Boolean.parseBoolean(normalizeBoolean(question.getCorrectAnswer()));
+        }
+        return question.getCorrectAnswer();
+    }
+
+    private String buildQuriMessage(int scorePercent, int correctCount, Integer totalQuestions, List<String> weakTopics) {
+        if (scorePercent == 100) {
+            return "완벽해요! 🎉 노트 정리를 정말 잘 하셨네요!";
+        }
+        if (scorePercent >= 80) {
+            String topic = weakTopics == null || weakTopics.isEmpty() ? "헷갈린" : weakTopics.get(0);
+            int total = totalQuestions == null ? 0 : totalQuestions;
+            return total + "문제 중 " + correctCount + "개를 맞혔어요! '" + topic + "' 부분을 노트에서 한 번 더 확인해 보세요.";
+        }
+        if (scorePercent >= 60) {
+            return "절반 이상 맞혔어요! 노트를 보충하고 다시 도전해 볼까요?";
+        }
+        if (scorePercent >= 40) {
+            return "조금 어려웠나요? 노트를 다시 읽어보고 한 번 더 풀어봐요!";
+        }
+        return "괜찮아요! 노트를 보충하면 다음에는 더 잘 할 수 있어요 💪";
+    }
+
+    private boolean matchesKeywords(String user, List<String> keywords) {
+        if (user == null || keywords == null) return false;
+        String normalizedUser = normalize(user).toLowerCase();
+        return keywords.stream().filter(Objects::nonNull).map(String::trim).map(String::toLowerCase).anyMatch(normalizedUser::equals);
+    }
+
+    private String writeJson(Object value) {
+        try { return objectMapper.writeValueAsString(value); } catch (Exception e) { throw new IllegalStateException(e); }
+    }
+
+    private QuizSubmitResponse toResponse(QuizResult result, QuizSession session) {
+        try {
+            return QuizSubmitResponse.builder()
+                    .quizSessionId(session.getId())
+                    .totalQuestions(result.getTotalQuestions())
+                    .correctCount(result.getCorrectCount())
+                    .scorePercent(result.getScorePercent())
+                    .results(objectMapper.readValue(result.getAnswersJson(), objectMapper.getTypeFactory().constructCollectionType(List.class, QuizSubmitResponse.ResultDto.class)))
+                    .quriMessage(buildQuriMessage(result.getScorePercent(), result.getCorrectCount(), result.getTotalQuestions(), readWeakTopics(result.getWeakTopicsJson())))
+                    .weakTopics(readWeakTopics(result.getWeakTopicsJson()))
+                    .build();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private List<String> readWeakTopics(String weakTopicsJson) throws java.io.IOException {
+        if (weakTopicsJson == null || weakTopicsJson.isBlank()) {
+            return List.of();
+        }
+        return objectMapper.readValue(weakTopicsJson, objectMapper.getTypeFactory().constructCollectionType(List.class, String.class));
     }
 }

--- a/src/main/java/com/example/kuriq/service/QuizService.java
+++ b/src/main/java/com/example/kuriq/service/QuizService.java
@@ -1,0 +1,138 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.client.AiClient;
+import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
+import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
+import com.example.kuriq.entity.quiz.QuizOption;
+import com.example.kuriq.entity.quiz.QuizQuestion;
+import com.example.kuriq.entity.quiz.QuizQuestionType;
+import com.example.kuriq.entity.quiz.QuizSession;
+import com.example.kuriq.repository.quiz.QuizSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizService {
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final AiClient aiClient;
+
+    public QuizGenerateResponse generate(QuizGenerateRequest request, String userId) {
+        validateExcludedSessions(request.getExcludeSessionIds(), userId);
+
+        AiClient.QuizGenerateAiResponse aiResponse = aiClient.generateQuiz(
+                AiClient.QuizGenerateAiRequest.builder()
+                        .noteId(request.getNoteId())
+                        .excludeSessionIds(request.getExcludeSessionIds())
+                        .userId(userId)
+                        .build());
+        validateAiResponse(aiResponse);
+
+        QuizSession session = QuizSession.builder()
+                .userId(userId)
+                .courseId(aiResponse.getCourseId())
+                .noteId(request.getNoteId())
+                .build();
+
+        for (int questionIndex = 0; questionIndex < aiResponse.getQuestions().size(); questionIndex++) {
+            AiClient.QuizGenerateAiResponse.QuestionDto q = aiResponse.getQuestions().get(questionIndex);
+            QuizQuestion question = QuizQuestion.builder()
+                    .quizSession(session)
+                    .type(QuizQuestionType.valueOf(q.getType()))
+                    .orderIndex(questionIndex)
+                    .question(q.getQuestion())
+                    .build();
+            if (q.getOptions() != null) {
+                for (int optionIndex = 0; optionIndex < q.getOptions().size(); optionIndex++) {
+                    AiClient.QuizGenerateAiResponse.OptionDto o = q.getOptions().get(optionIndex);
+                    question.getOptions().add(QuizOption.builder()
+                            .quizQuestion(question)
+                            .optionId(o.getId())
+                            .orderIndex(optionIndex)
+                            .text(o.getText())
+                            .build());
+                }
+            }
+            session.getQuestions().add(question);
+        }
+
+        quizSessionRepository.save(session);
+
+        return QuizGenerateResponse.builder()
+                .quizSessionId(session.getId())
+                .courseId(session.getCourseId())
+                .noteId(session.getNoteId())
+                .questions(session.getQuestions().stream().map(q -> QuizGenerateResponse.QuestionDto.builder()
+                        .questionId(q.getId())
+                        .type(q.getType().name())
+                        .question(q.getQuestion())
+                        .options(q.getType() == QuizQuestionType.MULTIPLE_CHOICE ? q.getOptions().stream()
+                                .map(o -> QuizGenerateResponse.OptionDto.builder()
+                                        .id(o.getOptionId())
+                                        .text(o.getText())
+                                        .build())
+                                .collect(Collectors.toList()) : null)
+                        .build()).collect(Collectors.toList()))
+                .build();
+    }
+
+    private void validateExcludedSessions(List<String> excludeSessionIds, String userId) {
+        if (excludeSessionIds == null || excludeSessionIds.isEmpty()) {
+            return;
+        }
+
+        Set<String> distinctIds = new HashSet<>(excludeSessionIds);
+        long ownedCount = quizSessionRepository.countByIdInAndUserId(distinctIds, userId);
+        if (ownedCount != distinctIds.size()) {
+            throw new IllegalArgumentException("제외할 퀴즈 세션을 찾을 수 없거나 접근 권한이 없습니다");
+        }
+    }
+
+    private void validateAiResponse(AiClient.QuizGenerateAiResponse response) {
+        if (response == null || isBlank(response.getCourseId()) || response.getQuestions() == null || response.getQuestions().isEmpty()) {
+            throw new RuntimeException("AI 퀴즈 생성 응답이 올바르지 않습니다");
+        }
+
+        for (AiClient.QuizGenerateAiResponse.QuestionDto question : response.getQuestions()) {
+            if (question == null || isBlank(question.getType()) || isBlank(question.getQuestion())) {
+                throw new RuntimeException("AI 퀴즈 문항 응답이 올바르지 않습니다");
+            }
+
+            QuizQuestionType type;
+            try {
+                type = QuizQuestionType.valueOf(question.getType());
+            } catch (IllegalArgumentException e) {
+                throw new RuntimeException("지원하지 않는 퀴즈 유형입니다: " + question.getType(), e);
+            }
+
+            if (type == QuizQuestionType.MULTIPLE_CHOICE) {
+                if (question.getOptions() == null || question.getOptions().isEmpty()) {
+                    throw new RuntimeException("객관식 문항에는 선택지가 필요합니다");
+                }
+
+                boolean invalidOption = question.getOptions().stream()
+                        .anyMatch(option -> option == null || isBlank(option.getId()) || isBlank(option.getText()));
+                if (invalidOption) {
+                    throw new RuntimeException("AI 퀴즈 선택지 응답이 올바르지 않습니다");
+                }
+            }
+
+            if (type != QuizQuestionType.MULTIPLE_CHOICE && question.getOptions() != null) {
+                question.setOptions(null);
+            }
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return Objects.isNull(value) || value.isBlank();
+    }
+}

--- a/src/main/java/com/example/kuriq/service/QuizService.java
+++ b/src/main/java/com/example/kuriq/service/QuizService.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.service;
 
 import com.example.kuriq.client.AiClient;
+import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
 import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
 import com.example.kuriq.entity.quiz.QuizOption;
@@ -8,7 +9,12 @@ import com.example.kuriq.entity.quiz.QuizQuestion;
 import com.example.kuriq.entity.quiz.QuizQuestionType;
 import com.example.kuriq.entity.quiz.QuizSession;
 import com.example.kuriq.repository.quiz.QuizSessionRepository;
+import com.example.kuriq.repository.roadmap.CourseRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +30,7 @@ import java.util.stream.Collectors;
 public class QuizService {
 
     private final QuizSessionRepository quizSessionRepository;
+    private final CourseRepository courseRepository;
     private final AiClient aiClient;
 
     public QuizGenerateResponse generate(QuizGenerateRequest request, String userId) {
@@ -41,6 +48,7 @@ public class QuizService {
                 .userId(userId)
                 .courseId(aiResponse.getCourseId())
                 .noteId(request.getNoteId())
+                .totalQuestions(aiResponse.getQuestions().size())
                 .build();
 
         for (int questionIndex = 0; questionIndex < aiResponse.getQuestions().size(); questionIndex++) {
@@ -83,6 +91,23 @@ public class QuizService {
                                 .collect(Collectors.toList()) : null)
                         .build()).collect(Collectors.toList()))
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public QuizHistoryResponse history(String userId, String courseId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        var sessions = courseId == null || courseId.isBlank()
+                ? quizSessionRepository.findByUserId(userId, pageable)
+                : quizSessionRepository.findByUserIdAndCourseId(userId, courseId, pageable);
+
+        var content = sessions.getContent().stream().map(session -> {
+            String courseTitle = courseRepository.findById(session.getCourseId())
+                    .map(course -> course.getTitle())
+                    .orElse(null);
+            return QuizHistoryResponse.Item.from(session, courseTitle);
+        }).toList();
+
+        return QuizHistoryResponse.from(new PageImpl<>(content, pageable, sessions.getTotalElements()));
     }
 
     private void validateExcludedSessions(List<String> excludeSessionIds, String userId) {

--- a/src/main/java/com/example/kuriq/service/QuizService.java
+++ b/src/main/java/com/example/kuriq/service/QuizService.java
@@ -1,9 +1,11 @@
 package com.example.kuriq.service;
 
 import com.example.kuriq.client.AiClient;
+import com.example.kuriq.dto.quiz.request.QuizSubmitRequest;
 import com.example.kuriq.dto.quiz.response.QuizHistoryResponse;
 import com.example.kuriq.dto.quiz.request.QuizGenerateRequest;
 import com.example.kuriq.dto.quiz.response.QuizGenerateResponse;
+import com.example.kuriq.dto.quiz.response.QuizSubmitResponse;
 import com.example.kuriq.entity.quiz.QuizOption;
 import com.example.kuriq.entity.quiz.QuizQuestion;
 import com.example.kuriq.entity.quiz.QuizQuestionType;
@@ -22,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -58,6 +61,10 @@ public class QuizService {
                     .type(QuizQuestionType.valueOf(q.getType()))
                     .orderIndex(questionIndex)
                     .question(q.getQuestion())
+                    .correctAnswer(q.getCorrectAnswer())
+                    .explanation(q.getExplanation())
+                    .noteReference(q.getNoteReference())
+                    .weakTopic(q.getWeakTopic())
                     .build();
             if (q.getOptions() != null) {
                 for (int optionIndex = 0; optionIndex < q.getOptions().size(); optionIndex++) {
@@ -110,6 +117,54 @@ public class QuizService {
         return QuizHistoryResponse.from(new PageImpl<>(content, pageable, sessions.getTotalElements()));
     }
 
+    public QuizSubmitResponse submit(String quizSessionId, QuizSubmitRequest request, String userId) {
+        QuizSession session = quizSessionRepository.findById(quizSessionId)
+                .orElseThrow(() -> new IllegalArgumentException("퀴즈 세션을 찾을 수 없습니다"));
+        if (!Objects.equals(session.getUserId(), userId)) {
+            throw new IllegalArgumentException("퀴즈 세션에 접근 권한이 없습니다");
+        }
+
+        Map<String, QuizQuestion> questionMap = session.getQuestions().stream()
+                .collect(Collectors.toMap(QuizQuestion::getId, q -> q));
+        Set<String> submittedIds = new HashSet<>();
+        List<QuizSubmitResponse.ResultDto> results = new java.util.ArrayList<>();
+        Set<String> weakTopics = new java.util.LinkedHashSet<>();
+        int correctCount = 0;
+
+        for (QuizSubmitRequest.AnswerDto answerDto : request.getAnswers()) {
+            if (!submittedIds.add(answerDto.getQuestionId())) {
+                throw new IllegalArgumentException("중복된 questionId가 있습니다");
+            }
+            QuizQuestion question = questionMap.get(answerDto.getQuestionId());
+            if (question == null) {
+                throw new IllegalArgumentException("세션에 포함되지 않은 questionId가 있습니다");
+            }
+
+            var evaluated = evaluate(question, answerDto.getAnswer());
+            if (Boolean.TRUE.equals(evaluated.getIsCorrect())) correctCount++;
+            if (evaluated.getWeakTopic() != null) weakTopics.add(evaluated.getWeakTopic());
+            results.add(evaluated);
+        }
+
+        if (submittedIds.size() != questionMap.size()) {
+            throw new IllegalArgumentException("모든 문항의 답안을 제출해 주세요");
+        }
+
+        session.submitScore(correctCount);
+        quizSessionRepository.save(session);
+
+        int scorePercent = calculateScorePercent(correctCount, session.getTotalQuestions());
+        return QuizSubmitResponse.builder()
+                .quizSessionId(session.getId())
+                .totalQuestions(session.getTotalQuestions())
+                .correctCount(correctCount)
+                .scorePercent(scorePercent)
+                .results(results)
+                .quriMessage(scorePercent >= 80 ? "잘했어요!" : "다시 복습해봐요.")
+                .weakTopics(new java.util.ArrayList<>(weakTopics))
+                .build();
+    }
+
     private void validateExcludedSessions(List<String> excludeSessionIds, String userId) {
         if (excludeSessionIds == null || excludeSessionIds.isEmpty()) {
             return;
@@ -131,6 +186,9 @@ public class QuizService {
             if (question == null || isBlank(question.getType()) || isBlank(question.getQuestion())) {
                 throw new RuntimeException("AI 퀴즈 문항 응답이 올바르지 않습니다");
             }
+            if (isBlank(question.getCorrectAnswer())) {
+                throw new RuntimeException("AI 퀴즈 정답 응답이 올바르지 않습니다");
+            }
 
             QuizQuestionType type;
             try {
@@ -149,6 +207,20 @@ public class QuizService {
                 if (invalidOption) {
                     throw new RuntimeException("AI 퀴즈 선택지 응답이 올바르지 않습니다");
                 }
+
+                boolean hasCorrectOption = question.getOptions().stream()
+                        .anyMatch(option -> normalize(option.getId()).equals(normalize(question.getCorrectAnswer())));
+                if (!hasCorrectOption) {
+                    throw new RuntimeException("객관식 정답이 선택지에 없습니다");
+                }
+            }
+
+            if (type == QuizQuestionType.TRUE_FALSE) {
+                String correct = normalizeBoolean(question.getCorrectAnswer());
+                if (!"true".equals(correct) && !"false".equals(correct)) {
+                    throw new RuntimeException("True/False 정답은 true 또는 false여야 합니다");
+                }
+                question.setCorrectAnswer(correct);
             }
 
             if (type != QuizQuestionType.MULTIPLE_CHOICE && question.getOptions() != null) {
@@ -159,5 +231,62 @@ public class QuizService {
 
     private boolean isBlank(String value) {
         return Objects.isNull(value) || value.isBlank();
+    }
+
+    private QuizSubmitResponse.ResultDto evaluate(QuizQuestion question, Object answer) {
+        String type = question.getType().name();
+        String correct = question.getCorrectAnswer();
+        boolean isCorrect;
+        String result = "WRONG";
+        String feedback = null;
+        String weakTopic = null;
+
+        if (question.getType() == QuizQuestionType.MULTIPLE_CHOICE) {
+            if (answer != null && !(answer instanceof String)) throw new IllegalArgumentException("객관식 답안은 문자열이어야 합니다");
+            String user = answer == null ? null : String.valueOf(answer);
+            isCorrect = normalize(user).equals(normalize(correct));
+        } else if (question.getType() == QuizQuestionType.TRUE_FALSE) {
+            if (answer != null && !(answer instanceof Boolean) && !(answer instanceof String)) throw new IllegalArgumentException("True/False 답안은 boolean 또는 문자열이어야 합니다");
+            String user = normalizeBoolean(answer);
+            isCorrect = normalize(user).equals(normalizeBoolean(correct));
+        } else {
+            if (answer != null && !(answer instanceof String)) throw new IllegalArgumentException("단답형 답안은 문자열이어야 합니다");
+            String user = answer == null ? null : String.valueOf(answer);
+            isCorrect = normalize(user).equalsIgnoreCase(normalize(correct));
+            if (!isCorrect && "배열".equals(normalize(user)) && "리스트".equals(normalize(correct))) {
+                result = "PARTIAL";
+                feedback = "'배열'은 유사한 개념이지만 정답은 '리스트'입니다.";
+                weakTopic = question.getWeakTopic();
+            }
+        }
+
+        if (isCorrect) result = "CORRECT";
+        if (!isCorrect && weakTopic == null) weakTopic = question.getWeakTopic();
+
+        return QuizSubmitResponse.ResultDto.builder()
+                .questionId(question.getId())
+                .type(type)
+                .isCorrect(isCorrect)
+                .result(result)
+                .userAnswer(answer)
+                .correctAnswer(correct)
+                .explanation(question.getExplanation())
+                .feedback(feedback)
+                .noteReference(question.getNoteReference())
+                .weakTopic(weakTopic)
+                .build();
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private String normalizeBoolean(Object value) {
+        if (value instanceof Boolean b) return String.valueOf(b);
+        return value == null ? null : String.valueOf(value).trim().toLowerCase();
+    }
+
+    private int calculateScorePercent(int correctCount, Integer totalQuestions) {
+        return totalQuestions == null || totalQuestions == 0 ? 0 : (correctCount * 100) / totalQuestions;
     }
 }


### PR DESCRIPTION
## Summary
- AI 노트 정리, 조회, 자동 저장, 삭제 API 구현
- 주간 대시보드 조회 API 구현
- 기존 노트 기반 퀴즈·채팅 기능 포함

## AI 노트 API
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/v1/notes` | 노트 생성 |
| GET | `/api/v1/notes?courseId={courseId}` | 강좌별 노트 조회 |
| PUT | `/api/v1/notes/{noteId}` | 자동 저장 (debounce 3초) |
| POST | `/api/v1/notes/{noteId}/ai-organize` | AI 노트 정리 (키워드, 요약, 제안) |
| DELETE | `/api/v1/notes/{noteId}` | 노트 삭제 (관련 퀴즈·채팅 이력 동시 삭제) |

## 주간 대시보드 API
| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/api/v1/dashboard/weekly?roadmapId={id}&weekNumber={n}` | 주차별 학습 현황 조회 (weekNumber 생략 시 현재 주차 자동 산정) |

## 변경 파일
- `AiClient.java` — `/internal/ai/organize` 호출 메서드 추가
- `NoteController.java`, `NoteService.java` — 노트 CRUD + AI 정리
- `DashboardController.java`, `DashboardService.java` — 주간 대시보드
- `LearningNote.java`, `LearningNoteRepository.java` — 엔티티/레포지토리 확장
- `QuizSessionRepository.java` — 노트 기반 퀴즈 세션 삭제
- 신규 DTO 5개 (`AiOrganizeResponse`, `NoteDetailResponse`, `NoteSaveResponse`, `NoteSaveRequest`, `WeeklyDashboardResponse`)