### PR TITLE
feat: 게시판, 리뷰, 뱃지 기능 구현

### DIFF
--- a/src/main/java/com/example/kuriq/config/SecurityConfig.java
+++ b/src/main/java/com/example/kuriq/config/SecurityConfig.java
@@ -51,7 +51,9 @@ public class SecurityConfig {
                         // 소셜 로그인 인증 URL 요청
                         .requestMatchers(HttpMethod.GET,
                                 "/api/v1/auth/social/**",
-                                "/api/v1/analytics/courses/popular"
+                                "/api/v1/analytics/courses/popular",
+                                "/api/v1/posts",         // 게시판 목록 비로그인 조회
+                                "/api/v1/posts/**"       // 게시판 상세 비로그인 조회
                         ).permitAll()
 
                         // 알림 수신 거부는 PATCH 메서드로 별도 추가

--- a/src/main/java/com/example/kuriq/controller/BadgeController.java
+++ b/src/main/java/com/example/kuriq/controller/BadgeController.java
@@ -1,0 +1,36 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.badge.BadgeResponse;
+import com.example.kuriq.service.BadgeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "Badge", description = "뱃지 API")
+@RestController
+@RequestMapping("/api/v1/users/me/badges")
+@RequiredArgsConstructor
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    // 전체 뱃지 목록을 BadgeType 선언 순서대로 반환
+    @Operation(
+            summary = "내 뱃지 목록 조회",
+            description = "전체 뱃지 목록을 반환합니다. 획득한 뱃지는 acquired=true, 미획득 뱃지는 acquired=false입니다."
+    )
+    @GetMapping
+    public ResponseEntity<List<BadgeResponse>> getMyBadges(
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(badgeService.getMyBadges(userId));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/CourseReviewController.java
+++ b/src/main/java/com/example/kuriq/controller/CourseReviewController.java
@@ -1,0 +1,84 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.review.ReviewDto;
+import com.example.kuriq.service.CourseReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "수강 후기", description = "강좌 수강 후기 & 평점 API")
+@RestController
+@RequiredArgsConstructor
+public class CourseReviewController {
+
+    private final CourseReviewService reviewService;
+
+    // 평점 요약 (비로그인 가능)
+    @Operation(summary = "강좌 평점 요약 조회")
+    @GetMapping("/api/v1/courses/{courseId}/reviews/summary")
+    public ResponseEntity<ReviewDto.SummaryResponse> getSummary(@PathVariable String courseId) {
+        return ResponseEntity.ok(reviewService.getSummary(courseId));
+    }
+
+    // 리뷰 목록 (비로그인 가능)
+    @Operation(summary = "리뷰 목록 조회")
+    @GetMapping("/api/v1/courses/{courseId}/reviews")
+    public ResponseEntity<ReviewDto.PageResponse> getReviews(
+            @PathVariable String courseId,
+            @AuthenticationPrincipal String userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(reviewService.getReviews(courseId, userId, page, size));
+    }
+
+    // 리뷰 작성 (이수자만)
+    @Operation(summary = "리뷰 작성 — 해당 강좌 이수자만 가능")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/api/v1/courses/{courseId}/reviews")
+    public ResponseEntity<ReviewDto.ReviewResponse> createReview(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String courseId,
+            @Valid @RequestBody ReviewDto.CreateRequest req) {
+        return ResponseEntity.ok(reviewService.createReview(userId, courseId, req));
+    }
+
+    // 내 리뷰 수정
+    @Operation(summary = "내 리뷰 수정")
+    @SecurityRequirement(name = "bearerAuth")
+    @PutMapping("/api/v1/courses/{courseId}/reviews/me")
+    public ResponseEntity<ReviewDto.ReviewResponse> updateMyReview(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String courseId,
+            @Valid @RequestBody ReviewDto.UpdateRequest req) {
+        return ResponseEntity.ok(reviewService.updateMyReview(userId, courseId, req));
+    }
+
+    // 내 리뷰 삭제
+    @Operation(summary = "내 리뷰 삭제")
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/api/v1/courses/{courseId}/reviews/me")
+    public ResponseEntity<Void> deleteMyReview(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String courseId) {
+        reviewService.deleteMyReview(userId, courseId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 리뷰 좋아요 토글
+    // reviewId만으로 어느 강좌의 리뷰인지 서버에서 조회 가능하므로 courseId 불필요
+    @Operation(summary = "리뷰 좋아요 토글")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/api/v1/reviews/{reviewId}/like")
+    public ResponseEntity<ReviewDto.LikeResponse> toggleLike(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String reviewId) {
+        return ResponseEntity.ok(reviewService.toggleLike(userId, reviewId));
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/PostController.java
+++ b/src/main/java/com/example/kuriq/controller/PostController.java
@@ -1,0 +1,126 @@
+package com.example.kuriq.controller;
+
+import com.example.kuriq.dto.post.PostDto;
+import com.example.kuriq.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "게시판", description = "자유 게시판 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    // 최신순(기본) / 댓글많은순
+    @Operation(summary = "게시글 목록 조회")
+    @GetMapping
+    public ResponseEntity<List<PostDto.SummaryResponse>> getPosts(
+            @RequestParam(defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        List<PostDto.SummaryResponse> result = switch (sort) {
+            case "comments" -> postService.getPostsByComment(page, size);
+            default -> postService.getPostsLatest(page, size); // 기본: 최신순
+        };
+        return ResponseEntity.ok(result);
+    }
+
+    // 게시글 작성 (로그인 필요)
+    @Operation(summary = "게시글 작성")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping
+    public ResponseEntity<PostDto.SummaryResponse> createPost(
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody PostDto.CreateRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(postService.createPost(userId, req));
+    }
+
+    // 게시글 상세 조회 (비로그인 가능)
+    @Operation(summary = "게시글 상세 조회")
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDto.DetailResponse> getPost(
+            @PathVariable String postId,
+            @AuthenticationPrincipal String userId) { // 비로그인이면 null
+        return ResponseEntity.ok(postService.getPost(postId, userId));
+    }
+
+    // 게시글 수정 (본인만)
+    @Operation(summary = "게시글 수정")
+    @SecurityRequirement(name = "bearerAuth")
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostDto.SummaryResponse> updatePost(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String postId,
+            @Valid @RequestBody PostDto.UpdateRequest req) {
+        return ResponseEntity.ok(postService.updatePost(userId, postId, req));
+    }
+
+    // 게시글 삭제 (본인만)
+    @Operation(summary = "게시글 삭제")
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String postId) {
+        postService.deletePost(userId, postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 좋아요 토글 (로그인 필요)
+    @Operation(summary = "게시글 좋아요 토글")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/{postId}/like")
+    public ResponseEntity<PostDto.LikeResponse> toggleLike(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String postId) {
+        return ResponseEntity.ok(postService.toggleLike(userId, postId));
+    }
+
+    // 댓글 작성 (로그인 필요)
+    @Operation(summary = "댓글/대댓글 작성")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/{postId}/comments")
+    public ResponseEntity<PostDto.CommentResponse> createComment(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String postId,
+            @Valid @RequestBody PostDto.CommentCreateRequest req) {
+        return ResponseEntity.ok(postService.createComment(userId, postId, req));
+    }
+
+    // 댓글 수정 (본인만)
+    @Operation(summary = "댓글 수정")
+    @SecurityRequirement(name = "bearerAuth")
+    @PutMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<PostDto.CommentResponse> updateComment(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String postId, // URL 구조 유지용
+            @PathVariable String commentId,
+            @Valid @RequestBody PostDto.CommentUpdateRequest req) {
+        return ResponseEntity.ok(postService.updateComment(userId, commentId, req));
+    }
+
+    // 댓글 삭제 (본인만)
+    @Operation(summary = "댓글 삭제")
+    @SecurityRequirement(name = "bearerAuth")
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @AuthenticationPrincipal String userId,
+            @PathVariable String postId, // URL 구조 유지용
+            @PathVariable String commentId) {
+        postService.deleteComment(userId, commentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/kuriq/controller/PostController.java
+++ b/src/main/java/com/example/kuriq/controller/PostController.java
@@ -25,14 +25,14 @@ public class PostController {
     // 최신순(기본) / 댓글많은순
     @Operation(summary = "게시글 목록 조회")
     @GetMapping
-    public ResponseEntity<List<PostDto.SummaryResponse>> getPosts(
+    public ResponseEntity<PostDto.PageResponse> getPosts(
             @RequestParam(defaultValue = "latest") String sort,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
-        List<PostDto.SummaryResponse> result = switch (sort) {
+        PostDto.PageResponse result = switch (sort) {
             case "comments" -> postService.getPostsByComment(page, size);
-            default -> postService.getPostsLatest(page, size); // 기본: 최신순
+            default -> postService.getPostsLatest(page, size);
         };
         return ResponseEntity.ok(result);
     }
@@ -106,7 +106,7 @@ public class PostController {
     @PutMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<PostDto.CommentResponse> updateComment(
             @AuthenticationPrincipal String userId,
-            @PathVariable String postId, // URL 구조 유지용
+            @PathVariable String postId,
             @PathVariable String commentId,
             @Valid @RequestBody PostDto.CommentUpdateRequest req) {
         return ResponseEntity.ok(postService.updateComment(userId, commentId, req));
@@ -118,7 +118,7 @@ public class PostController {
     @DeleteMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @AuthenticationPrincipal String userId,
-            @PathVariable String postId, // URL 구조 유지용
+            @PathVariable String postId,
             @PathVariable String commentId) {
         postService.deleteComment(userId, commentId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/kuriq/dto/badge/BadgeResponse.java
+++ b/src/main/java/com/example/kuriq/dto/badge/BadgeResponse.java
@@ -1,0 +1,75 @@
+package com.example.kuriq.dto.badge;
+
+import com.example.kuriq.entity.badge.Badge;
+import com.example.kuriq.entity.badge.BadgeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class BadgeResponse {
+
+    // 뱃지 ID (미획득이면 null)
+    private String id;
+
+    // 뱃지 ENUM 키
+    private String badgeType;
+
+    // 뱃지 표시 이름
+    private String displayName;
+
+    // 뱃지 달성 메시지
+    private String description;
+
+    // 획득 여부
+    private boolean acquired;
+
+    // 획득 시각 (미획득이면 null)
+    private LocalDateTime acquiredAt;
+
+    // 변환 메서드
+
+    // 획득한 Badge 엔티티 -> 응답 DTO
+    public static BadgeResponse from(Badge badge) {
+        BadgeType type = badge.getBadgeType();
+        return BadgeResponse.builder()
+                .id(badge.getId())
+                .badgeType(type.name())
+                .displayName(type.getDisplayName())
+                .description(type.getDescription())
+                .acquired(true)
+                .acquiredAt(badge.getAcquiredAt())
+                .build();
+    }
+
+    // 미획득 뱃지 타입 -> 잠금 상태 DTO
+    private static BadgeResponse locked(BadgeType type) {
+        return BadgeResponse.builder()
+                .id(null)
+                .badgeType(type.name())
+                .displayName(type.getDisplayName())
+                .description(type.getDescription())
+                .acquired(false)
+                .acquiredAt(null)
+                .build();
+    }
+
+    // 전체 뱃지 목록 응답 (획득 + 미획득 모두 포함)
+    public static List<BadgeResponse> buildFullList(List<Badge> acquiredBadges) {
+        Map<BadgeType, Badge> badgeMap = acquiredBadges.stream()
+                .collect(Collectors.toMap(Badge::getBadgeType, badge -> badge));
+
+        return Arrays.stream(BadgeType.values())
+                .map(type -> {
+                    Badge badge = badgeMap.get(type);
+                    return badge != null ? from(badge) : locked(type);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/post/PostDto.java
+++ b/src/main/java/com/example/kuriq/dto/post/PostDto.java
@@ -1,0 +1,154 @@
+package com.example.kuriq.dto.post;
+
+import com.example.kuriq.entity.post.Post;
+import com.example.kuriq.entity.post.PostComment;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PostDto {
+
+    /* 요청 */
+
+    // 게시글 작성 요청
+    @Getter
+    public static class CreateRequest {
+        @NotBlank(message = "제목을 입력해주세요.")
+        @Size(max = 50, message = "제목은 최대 50자까지 입력할 수 있습니다.")
+        private String title;
+
+        @NotBlank(message = "본문을 입력해주세요.")
+        private String content;
+    }
+
+    // 게시글 수정 요청
+    @Getter
+    public static class UpdateRequest {
+        @NotBlank(message = "제목을 입력해주세요.")
+        @Size(max = 50, message = "제목은 최대 50자까지 입력할 수 있습니다.")
+        private String title;
+
+        @NotBlank(message = "본문을 입력해주세요.")
+        private String content;
+    }
+
+    // 댓글 작성 요청
+    @Getter
+    public static class CommentCreateRequest {
+        @NotBlank(message = "댓글 내용을 입력해주세요.")
+        private String content;
+
+        // 대댓글인 경우 부모 댓글 ID (최상위 댓글이면 null)
+        private String parentId;
+    }
+
+    // 댓글 수정 요청
+    @Getter
+    public static class CommentUpdateRequest {
+        @NotBlank(message = "댓글 내용을 입력해주세요.")
+        private String content;
+    }
+
+    /* 응답 */
+
+    // 게시글 목록 응답 (목록에서 사용)
+    @Getter
+    @Builder
+    public static class SummaryResponse {
+        private String id;
+        private String title;
+        private String authorName;
+        private int viewCount;
+        private int likeCount;
+        private int commentCount;
+        private LocalDateTime createdAt;
+
+        public static SummaryResponse from(Post post, String authorName) {
+            return SummaryResponse.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .authorName(authorName)
+                    .viewCount(post.getViewCount())
+                    .likeCount(post.getLikeCount())
+                    .commentCount(post.getCommentCount())
+                    .createdAt(post.getCreatedAt())
+                    .build();
+        }
+    }
+
+    // 게시글 상세 응답
+    @Getter
+    @Builder
+    public static class DetailResponse {
+        private String id;
+        private String title;
+        private String content;
+        private String authorId;
+        private String authorName;
+        private int viewCount;
+        private int likeCount;
+        private int commentCount;
+        private boolean likedByMe;  // 로그인 사용자의 좋아요 여부
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private List<CommentResponse> comments;
+
+        public static DetailResponse from(Post post, String authorName,
+                                          boolean likedByMe, List<CommentResponse> comments) {
+            return DetailResponse.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .authorId(post.getUserId())
+                    .authorName(authorName)
+                    .viewCount(post.getViewCount())
+                    .likeCount(post.getLikeCount())
+                    .commentCount(post.getCommentCount())
+                    .likedByMe(likedByMe)
+                    .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .comments(comments)
+                    .build();
+        }
+    }
+
+    // 댓글 응답 (대댓글 포함)
+    @Getter
+    @Builder
+    public static class CommentResponse {
+        private String id;
+        private String authorId;
+        private String authorName;
+        private String content;
+        private boolean isDeleted;
+        private String parentId;
+        private LocalDateTime createdAt;
+        private List<CommentResponse> replies; // 대댓글 목록
+
+        public static CommentResponse from(PostComment comment, String authorName,
+                                           List<CommentResponse> replies) {
+            return CommentResponse.builder()
+                    .id(comment.getId())
+                    .authorId(comment.getUserId())
+                    .authorName(comment.isDeleted() ? null : authorName)
+                    .content(comment.getContent())
+                    .isDeleted(comment.isDeleted())
+                    .parentId(comment.getParentId())
+                    .createdAt(comment.getCreatedAt())
+                    .replies(replies)
+                    .build();
+        }
+    }
+
+    // 좋아요 토글 응답
+    @Getter
+    @Builder
+    public static class LikeResponse {
+        private boolean liked;   // 현재 좋아요 상태
+        private int likeCount;   // 변경된 좋아요 수
+    }
+}

--- a/src/main/java/com/example/kuriq/dto/post/PostDto.java
+++ b/src/main/java/com/example/kuriq/dto/post/PostDto.java
@@ -12,6 +12,17 @@ import java.util.List;
 
 public class PostDto {
 
+    // 페이지네이션 응답 래퍼
+    @Getter
+    @Builder
+    public static class PageResponse {
+        private List<SummaryResponse> content;
+        private int currentPage;
+        private int totalPages;
+        private long totalElements;
+        private boolean hasNext;
+    }
+
     /* 요청 */
 
     // 게시글 작성 요청

--- a/src/main/java/com/example/kuriq/dto/review/ReviewDto.java
+++ b/src/main/java/com/example/kuriq/dto/review/ReviewDto.java
@@ -1,0 +1,100 @@
+package com.example.kuriq.dto.review;
+
+import com.example.kuriq.entity.review.CourseReview;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ReviewDto {
+
+    // 페이지네이션 응답 래퍼
+    @Getter
+    @Builder
+    public static class PageResponse {
+        private List<ReviewResponse> content;
+        private int currentPage;
+        private int totalPages;
+        private long totalElements;
+        private boolean hasNext;
+    }
+
+    /*** 요청 ***/
+
+    @Getter
+    public static class CreateRequest {
+        @Min(value = 1, message = "별점은 최소 1점입니다.")
+        @Max(value = 5, message = "별점은 최대 5점입니다.")
+        private int rating;
+
+        @Size(max = 1000, message = "후기는 최대 1,000자까지 입력할 수 있습니다.")
+        private String content; // 선택
+
+        private CourseReview.PriorKnowledge priorKnowledge; // 선택
+
+        private CourseReview.DifficultyMatch difficultyMatch; // 선택
+    }
+
+    @Getter
+    public static class UpdateRequest {
+        @Min(value = 1, message = "별점은 최소 1점입니다.")
+        @Max(value = 5, message = "별점은 최대 5점입니다.")
+        private int rating;
+
+        @Size(max = 1000, message = "후기는 최대 1,000자까지 입력할 수 있습니다.")
+        private String content; // 선택
+
+        private CourseReview.PriorKnowledge priorKnowledge; // 선택
+
+        private CourseReview.DifficultyMatch difficultyMatch; // 선택
+    }
+
+    /*** 응답 ***/
+
+    // 강좌 평점 요약 (상단 표시용)
+    @Getter
+    @Builder
+    public static class SummaryResponse {
+        private double averageRating; // 소수점 1자리 반올림
+        private long reviewCount;
+    }
+
+    // 리뷰 상세
+    @Getter
+    @Builder
+    public static class ReviewResponse {
+        private String id;
+        private String authorId;
+        private String authorName;
+        private int rating;
+        private String content;
+        private CourseReview.PriorKnowledge priorKnowledge; // 사전 지식 수준
+        private CourseReview.DifficultyMatch difficultyMatch; // 난이도 체감
+        private int likeCount;
+        private boolean likedByMe;
+        private LocalDateTime createdAt;
+
+        public static ReviewResponse from(CourseReview review, String authorName, boolean likedByMe) {
+            return ReviewResponse.builder()
+                    .id(review.getId())
+                    .authorId(review.getUserId())
+                    .authorName(authorName)
+                    .rating(review.getRating())
+                    .content(review.getContent())
+                    .priorKnowledge(review.getPriorKnowledge())
+                    .difficultyMatch(review.getDifficultyMatch())
+                    .likeCount(review.getLikeCount())
+                    .likedByMe(likedByMe)
+                    .createdAt(review.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class LikeResponse {
+        private boolean liked;
+        private int likeCount;
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/badge/Badge.java
+++ b/src/main/java/com/example/kuriq/entity/badge/Badge.java
@@ -1,0 +1,53 @@
+package com.example.kuriq.entity.badge;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "badges",
+        indexes = {
+                @Index(name = "idx_badges_user_acquired", columnList = "user_id, acquired_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_badge_user_type", columnNames = {"user_id", "badge_type"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Badge {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 뱃지 소유 사용자 ID
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    // 뱃지 종류
+    @Enumerated(EnumType.STRING)
+    @Column(name = "badge_type", nullable = false, length = 30)
+    private BadgeType badgeType;
+
+    // 뱃지 획득 시각
+    @Column(name = "acquired_at", nullable = false, updatable = false)
+    private LocalDateTime acquiredAt;
+
+    @PrePersist
+    private void prePersist() {
+        acquiredAt = LocalDateTime.now();
+    }
+
+    // 팩토리 메서드
+    public static Badge of(String userId, BadgeType badgeType) {
+        Badge badge = new Badge();
+        badge.userId = userId;
+        badge.badgeType = badgeType;
+        return badge;
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/badge/BadgeType.java
+++ b/src/main/java/com/example/kuriq/entity/badge/BadgeType.java
@@ -1,0 +1,42 @@
+package com.example.kuriq.entity.badge;
+
+public enum BadgeType {
+
+    // 학습 첫 시작
+    SEEDLING("새싹 학습자", "첫 강좌를 완료했어요!"),
+
+    // 연속 학습 스트릭
+    STREAK_3("3일 불꽃", "3일 연속 강좌를 완료했어요!"),
+    STREAK_7("일주일 완주", "7일 연속 강좌를 완료했어요!"),
+    STREAK_30("한 달의 기적", "30일 연속 강좌를 완료했어요!"),
+    STREAK_100("멈출 수 없어", "100일 연속 강좌를 완료했어요!"),
+
+    // 누적 강좌 완료
+    COURSE_5("다섯 걸음", "강좌를 누적 5개 완료했어요!"),
+    COURSE_10("열 걸음", "강좌를 누적 10개 완료했어요!"),
+    COURSE_30("학습 고수", "강좌를 누적 30개 완료했어요!"),
+
+    // 로드맵 전체 이수
+    ROADMAP_1("길을 완주했다", "로드맵 1개를 전체 이수 완료했어요!"),
+    ROADMAP_3("세 갈래 길", "로드맵 3개를 전체 이수 완료했어요!"),
+
+    // 커뮤니티 활동
+    FIRST_POST("드디어 한마디", "커뮤니티에 첫 게시글을 작성했어요!"),
+
+    // 마스터 (위의 모든 뱃지 달성 시 자동 부여)
+    QURI_MASTER("큐리 마스터", "모든 뱃지를 달성했어요!");
+
+    // 뱃지 표시 이름
+    private final String displayName;
+
+    // 뱃지 달성 메시지
+    private final String description;
+
+    BadgeType(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() { return displayName; }
+    public String getDescription()  { return description; }
+}

--- a/src/main/java/com/example/kuriq/entity/post/Post.java
+++ b/src/main/java/com/example/kuriq/entity/post/Post.java
@@ -1,0 +1,108 @@
+package com.example.kuriq.entity.post;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "posts",
+        indexes = {
+                @Index(name = "idx_posts_user_created", columnList = "userId, createdAt"),
+                @Index(name = "idx_posts_comment", columnList = "commentCount"),       // 댓글많은순 정렬용
+                @Index(name = "idx_posts_active", columnList = "isDeleted, createdAt") // 활성 게시글 조회용
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Post {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 작성자 ID (users 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    // 제목 (최대 50자)
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    // 본문 (리치 텍스트 에디터 입력값)
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    // 조회수 캐시 — 동일 사용자/세션 1시간 내 중복 집계 제외
+    @Column(nullable = false)
+    @Builder.Default
+    private int viewCount = 0;
+
+    // 좋아요 수 캐시 — post_likes 테이블과 동기화
+    @Column(nullable = false)
+    @Builder.Default
+    private int likeCount = 0;
+
+    // 댓글 수 캐시 — 소프트 삭제 후에도 감소하지 않음
+    @Column(nullable = false)
+    @Builder.Default
+    private int commentCount = 0;
+
+    // true면 삭제된 상태(실제 DB에서 제거하지 않고 표시만 함)
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // 게시글 수정
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    // 소프트 삭제
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
+    // 좋아요 수 증가
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    // 좋아요 수 감소
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) this.likeCount--;
+    }
+
+    // 댓글 수 증가 — 소프트 삭제 시에도 감소하지 않으므로 증가만 있음
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    // 조회수 증가
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/post/PostComment.java
+++ b/src/main/java/com/example/kuriq/entity/post/PostComment.java
@@ -1,0 +1,77 @@
+package com.example.kuriq.entity.post;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "post_comments",
+        indexes = {
+                @Index(name = "idx_post_comments_post", columnList = "postId, createdAt"),
+                @Index(name = "idx_post_comments_parent", columnList = "parentId")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostComment {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 게시글 ID (posts 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String postId;
+
+    // 작성자 ID (users 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    // 부모 댓글 ID — 일반 댓글이면 null, 답글이면 원댓글의 id
+    @Column(length = 36)
+    private String parentId;
+
+    // 댓글 내용 — 소프트 삭제 시 "삭제된 댓글입니다."로 대체
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    // true면 삭제된 상태(실제 DB에서 제거하지 않고 표시만 함)
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // 댓글 수정 — 삭제된 댓글은 수정 불가
+    public void update(String content) {
+        if (this.isDeleted) throw new IllegalStateException("삭제된 댓글은 수정할 수 없습니다.");
+        this.content = content;
+    }
+
+    // 소프트 삭제 — 내용을 "삭제된 댓글입니다."로 대체
+    public void softDelete() {
+        this.isDeleted = true;
+        this.content = "삭제된 댓글입니다.";
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/post/PostLike.java
+++ b/src/main/java/com/example/kuriq/entity/post/PostLike.java
@@ -1,0 +1,45 @@
+package com.example.kuriq.entity.post;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "post_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_post_like",
+                        columnNames = {"postId", "userId"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostLike {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 게시글 ID (posts 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String postId;
+
+    // 좋아요 누른 사용자 ID (users 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/review/CourseReview.java
+++ b/src/main/java/com/example/kuriq/entity/review/CourseReview.java
@@ -1,0 +1,127 @@
+package com.example.kuriq.entity.review;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "course_reviews",
+        indexes = {
+                @Index(name = "uk_review_user_course", columnList = "userId, courseId", unique = true), // 1인 1리뷰
+                @Index(name = "idx_reviews_course_created", columnList = "courseId, createdAt"),
+                @Index(name = "idx_reviews_course_rating", columnList = "courseId, rating") // AVG(rating) 집계용
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CourseReview {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 작성자 ID (users 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    // 강좌 ID (courses 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String courseId;
+
+    // 별점 1~5 (필수)
+    @Column(nullable = false)
+    private int rating;
+
+    // 후기 본문 — 선택. 최대 1,000자
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    // 사전 지식 수준 — 선택. difficulty_match와 함께 표시
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private PriorKnowledge priorKnowledge;
+
+    // 난이도 체감 — 선택. prior_knowledge와 함께 표시
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private DifficultyMatch difficultyMatch;
+
+    // 리뷰 좋아요 수 캐시
+    @Column(nullable = false)
+    @Builder.Default
+    private int likeCount = 0;
+
+    // 소프트 삭제 여부
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /* ENUM */
+
+    // 사전 지식 수준
+    public enum PriorKnowledge {
+        BEGINNER,     // 처음 접해봐요
+        LITTLE,       // 조금 알아요
+        INTERMEDIATE, // 어느 정도 알아요
+        ADVANCED      // 잘 알아요
+    }
+
+    // 난이도 체감
+    public enum DifficultyMatch {
+        EASY, // 생각보다 쉬웠어요
+        FIT,  // 난이도가 딱 맞았어요
+        HARD  // 생각보다 어려웠어요
+    }
+
+    /* 생명주기 */
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    /* 비즈니스 메서드 */
+
+    // 리뷰 수정 — 삭제된 리뷰는 수정 불가
+    public void update(int rating, String content,
+                       PriorKnowledge priorKnowledge, DifficultyMatch difficultyMatch) {
+        if (this.isDeleted) throw new IllegalStateException("삭제된 리뷰는 수정할 수 없습니다.");
+        this.rating = rating;
+        this.content = content;
+        this.priorKnowledge = priorKnowledge;
+        this.difficultyMatch = difficultyMatch;
+    }
+
+    // 소프트 삭제
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
+    // 좋아요 수 증가
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    // 좋아요 수 감소
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) this.likeCount--;
+    }
+}

--- a/src/main/java/com/example/kuriq/entity/review/CourseReviewLike.java
+++ b/src/main/java/com/example/kuriq/entity/review/CourseReviewLike.java
@@ -1,0 +1,42 @@
+package com.example.kuriq.entity.review;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "course_review_likes",
+        indexes = {
+                @Index(name = "uk_review_like", columnList = "reviewId, userId", unique = true)
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CourseReviewLike {
+
+    @Id
+    @UuidGenerator
+    @Column(length = 36)
+    private String id;
+
+    // 리뷰 ID (course_reviews 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String reviewId;
+
+    // 좋아요 누른 사용자 ID (users 테이블 FK)
+    @Column(nullable = false, length = 36)
+    private String userId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/kuriq/repository/badge/BadgeRepository.java
+++ b/src/main/java/com/example/kuriq/repository/badge/BadgeRepository.java
@@ -1,0 +1,24 @@
+package com.example.kuriq.repository.badge;
+
+import com.example.kuriq.entity.badge.Badge;
+import com.example.kuriq.entity.badge.BadgeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BadgeRepository extends JpaRepository<Badge, String> {
+
+    List<Badge> findByUserIdOrderByAcquiredAtDesc(String userId);
+
+    boolean existsByUserIdAndBadgeType(String userId, BadgeType badgeType);
+
+    @Query("""
+        SELECT b.badgeType
+        FROM Badge b
+        WHERE b.userId = :userId
+        """)
+    List<BadgeType> findBadgeTypesByUserId(@Param("userId") String userId);
+}
+

--- a/src/main/java/com/example/kuriq/repository/post/PostCommentRepository.java
+++ b/src/main/java/com/example/kuriq/repository/post/PostCommentRepository.java
@@ -1,0 +1,16 @@
+package com.example.kuriq.repository.post;
+
+import com.example.kuriq.entity.post.PostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostCommentRepository extends JpaRepository<PostComment, String> {
+
+    // 게시글의 모든 댓글 + 대댓글 — 시간순 (서비스에서 최상위/대댓글 분리)
+    List<PostComment> findByPostIdOrderByCreatedAtAsc(String postId);
+
+    // 단건 조회 — 수정/삭제 작업용
+    Optional<PostComment> findByIdAndIsDeletedFalse(String id);
+}

--- a/src/main/java/com/example/kuriq/repository/post/PostLikeRepository.java
+++ b/src/main/java/com/example/kuriq/repository/post/PostLikeRepository.java
@@ -1,0 +1,18 @@
+package com.example.kuriq.repository.post;
+
+import com.example.kuriq.entity.post.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, String> {
+
+    // 좋아요 존재 여부 확인 — 토글 로직에 사용
+    boolean existsByPostIdAndUserId(String postId, String userId);
+
+    // 좋아요 단건 조회 — 취소 시 사용
+    Optional<PostLike> findByPostIdAndUserId(String postId, String userId);
+
+    // 특정 게시글의 좋아요 수 집계 — likeCount 캐시 재계산 필요 시 사용
+    long countByPostId(String postId);
+}

--- a/src/main/java/com/example/kuriq/repository/post/PostRepository.java
+++ b/src/main/java/com/example/kuriq/repository/post/PostRepository.java
@@ -1,0 +1,23 @@
+package com.example.kuriq.repository.post;
+
+import com.example.kuriq.entity.post.Post;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, String> {
+
+    // 전체 목록 — 최신순 (기본)
+    List<Post> findByIsDeletedFalseOrderByCreatedAtDesc(Pageable pageable);
+
+    // 전체 목록 — 댓글많은순, 같은 댓글 수면 최신순
+    List<Post> findByIsDeletedFalseOrderByCommentCountDescCreatedAtDesc(Pageable pageable);
+
+    // 단건 조회 — 삭제되지 않은 게시글만
+    Optional<Post> findByIdAndIsDeletedFalse(String id);
+
+    // 내 게시글 목록
+    List<Post> findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(String userId, Pageable pageable);
+}

--- a/src/main/java/com/example/kuriq/repository/post/PostRepository.java
+++ b/src/main/java/com/example/kuriq/repository/post/PostRepository.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.repository.post;
 
 import com.example.kuriq.entity.post.Post;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,14 +11,14 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, String> {
 
     // 전체 목록 — 최신순 (기본)
-    List<Post> findByIsDeletedFalseOrderByCreatedAtDesc(Pageable pageable);
+    Page<Post> findByIsDeletedFalseOrderByCreatedAtDesc(Pageable pageable);
 
     // 전체 목록 — 댓글많은순, 같은 댓글 수면 최신순
-    List<Post> findByIsDeletedFalseOrderByCommentCountDescCreatedAtDesc(Pageable pageable);
+    Page<Post> findByIsDeletedFalseOrderByCommentCountDescCreatedAtDesc(Pageable pageable);
 
     // 단건 조회 — 삭제되지 않은 게시글만
     Optional<Post> findByIdAndIsDeletedFalse(String id);
 
     // 내 게시글 목록
-    List<Post> findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(String userId, Pageable pageable);
+    Page<Post> findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(String userId, Pageable pageable);
 }

--- a/src/main/java/com/example/kuriq/repository/review/CourseReviewLikeRepository.java
+++ b/src/main/java/com/example/kuriq/repository/review/CourseReviewLikeRepository.java
@@ -1,0 +1,17 @@
+package com.example.kuriq.repository.review;
+
+import com.example.kuriq.entity.review.CourseReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CourseReviewLikeRepository extends JpaRepository<CourseReviewLike, String> {
+
+    boolean existsByReviewIdAndUserId(String reviewId, String userId);
+
+    Optional<CourseReviewLike> findByReviewIdAndUserId(String reviewId, String userId);
+
+    // 리뷰 좋아요 수 집계 — 뱃지 서비스에서 사용
+    long countByUserId(String userId);
+}
+

--- a/src/main/java/com/example/kuriq/repository/review/CourseReviewRepository.java
+++ b/src/main/java/com/example/kuriq/repository/review/CourseReviewRepository.java
@@ -1,0 +1,33 @@
+package com.example.kuriq.repository.review;
+
+import com.example.kuriq.entity.review.CourseReview;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseReviewRepository extends JpaRepository<CourseReview, String> {
+
+    // 강좌별 리뷰 목록 — 최신순
+    Page<CourseReview> findByCourseIdAndIsDeletedFalseOrderByCreatedAtDesc(String courseId, Pageable pageable);
+
+    // 특정 사용자의 특정 강좌 리뷰 조회 — 1인 1리뷰 확인, 수정/삭제용
+    Optional<CourseReview> findByUserIdAndCourseIdAndIsDeletedFalse(String userId, String courseId);
+
+    // 1인 1리뷰 중복 체크
+    boolean existsByUserIdAndCourseIdAndIsDeletedFalse(String userId, String courseId);
+
+    // 내 리뷰 목록
+    List<CourseReview> findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(String userId);
+
+    // 강좌 평균 별점 집계 — 삭제되지 않은 리뷰만
+    @Query("SELECT AVG(r.rating) FROM CourseReview r WHERE r.courseId = :courseId AND r.isDeleted = false")
+    Double calculateAverageRating(@Param("courseId") String courseId);
+
+    // 강좌 리뷰 수 집계
+    long countByCourseIdAndIsDeletedFalse(String courseId);
+}

--- a/src/main/java/com/example/kuriq/repository/roadmap/LearningHistoryRepository.java
+++ b/src/main/java/com/example/kuriq/repository/roadmap/LearningHistoryRepository.java
@@ -8,24 +8,10 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 
-/**
- * 학습 이력(LearningHistory) 저장소.
- *
- * 역할:
- * - 사용자의 강좌 이수 기록 저장 및 조회
- * - 마이페이지 통계 및 학습 분석 데이터 제공
- *
- * ERD 기준:
- * - LearningHistory는 “사용자가 실제로 학습을 완료한 기록”을 저장하는 로그 테이블
- * - RoadmapItem(계획)과 달리, 실제 수행된 학습 데이터를 의미
- *
- * 주요 사용처:
- * - 마이페이지 통계 (이수 개수, 총 학습 시간 등)
- * - 학습 패턴 분석 (연속 학습 일수, 활동 여부)
- * - 리마인드 알림 기준 데이터
- */
+// 학습 이력(LearningHistory) 저장
 public interface LearningHistoryRepository extends JpaRepository<LearningHistory, String> {
 
     // 사용자 이력 최신순 전체 조회
@@ -47,28 +33,39 @@ public interface LearningHistoryRepository extends JpaRepository<LearningHistory
     // 이수 강좌들의 estimated_hours 합산
     // courses 테이블 JOIN해서 SUM
     // COALESCE: 이력 없으면 SUM이 null → 0으로 대체
-    @Query("""
-        SELECT COALESCE(SUM(c.estimatedHours), 0)
-        FROM LearningHistory h
-        JOIN Course c ON c.id = h.courseId
-        WHERE h.userId = :userId
-        """)
+    @Query(value = """
+        SELECT COALESCE(SUM(c.estimated_hours), 0)
+        FROM learning_history h
+        JOIN courses c ON c.id = h.course_id
+        WHERE h.user_id = :userId
+        """, nativeQuery = true)
     BigDecimal sumEstimatedHoursByUserId(@Param("userId") String userId);
 
     // 카테고리별 이수 강좌 수 집계
     // 마이페이지 분야별 학습 현황용
     // category null인 강좌는 제외하고 집계
-    @Query("""
-        SELECT c.category, COUNT(h)
-        FROM LearningHistory h
-        JOIN Course c ON c.id = h.courseId
-        WHERE h.userId = :userId
+    @Query(value = """
+        SELECT c.category, COUNT(h.id)
+        FROM learning_history h
+        JOIN courses c ON c.id = h.course_id
+        WHERE h.user_id = :userId
           AND c.category IS NOT NULL
         GROUP BY c.category
-        ORDER BY COUNT(h) DESC
-        """)
+        ORDER BY COUNT(h.id) DESC
+        """, nativeQuery = true)
     List<Object[]> countByCategoryForUser(@Param("userId") String userId);
 
     // courseId 목록으로 이력 배치 조회
     List<LearningHistory> findByUserIdAndCourseIdIn(String userId, List<String> courseIds);
+
+    // 뱃지 스트릭 계산용
+    // BadgeService.calculateStreak() 에서 KST 날짜로 변환 후 연속 학습일 역산
+    // 전체 completedAt 내림차순 반환 (엔티티가 아닌 LocalDateTime 만 조회해 불필요한 컬럼 로드 방지)
+    @Query("""
+        SELECT h.completedAt
+        FROM LearningHistory h
+        WHERE h.userId = :userId
+        ORDER BY h.completedAt DESC
+        """)
+    List<LocalDateTime> findCompletedAtByUserIdOrderByDesc(@Param("userId") String userId);
 }

--- a/src/main/java/com/example/kuriq/service/BadgeService.java
+++ b/src/main/java/com/example/kuriq/service/BadgeService.java
@@ -1,0 +1,188 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.badge.BadgeResponse;
+import com.example.kuriq.entity.badge.Badge;
+import com.example.kuriq.entity.badge.BadgeType;
+import com.example.kuriq.repository.badge.BadgeRepository;
+import com.example.kuriq.repository.roadmap.LearningHistoryRepository;
+import com.example.kuriq.repository.roadmap.RoadmapRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    // QURI_MASTER 달성 조건 — 이 Set 의 뱃지를 전부 보유해야 부여됨.
+    private static final Set<BadgeType> REQUIRED_FOR_MASTER = Set.of(
+            BadgeType.SEEDLING,
+            BadgeType.STREAK_3,  BadgeType.STREAK_7,
+            BadgeType.STREAK_30, BadgeType.STREAK_100,
+            BadgeType.COURSE_5,  BadgeType.COURSE_10, BadgeType.COURSE_30,
+            BadgeType.ROADMAP_1, BadgeType.ROADMAP_3,
+            BadgeType.FIRST_POST
+    );
+
+    private final BadgeRepository badgeRepository;
+    private final LearningHistoryRepository learningHistoryRepository;
+    private final RoadmapRepository roadmapRepository;
+
+    //  내 뱃지 목록 조회
+    @Transactional(readOnly = true)
+    public List<BadgeResponse> getMyBadges(String userId) {
+        List<Badge> acquired = badgeRepository.findByUserIdOrderByAcquiredAtDesc(userId);
+        return BadgeResponse.buildFullList(acquired);
+    }
+
+    //  트리거 1: 강좌 완료
+    //  체크 대상: SEEDLING, COURSE_5/10/30, STREAK_3/7/30/100
+    @Async
+    @Transactional
+    public void checkAndAwardOnCourseComplete(String userId) {
+        List<BadgeType> awarded = new ArrayList<>();
+
+        // 누적 강좌 수 기반
+        long totalCompleted = learningHistoryRepository.countByUserId(userId);
+
+        if (totalCompleted >= 1)  award(userId, BadgeType.SEEDLING,   awarded);
+        if (totalCompleted >= 5)  award(userId, BadgeType.COURSE_5,   awarded);
+        if (totalCompleted >= 10) award(userId, BadgeType.COURSE_10,  awarded);
+        if (totalCompleted >= 30) award(userId, BadgeType.COURSE_30,  awarded);
+
+        // 연속 학습 스트릭 (KST 자정 기준)
+        int streak = calculateStreak(userId);
+
+        if (streak >= 3)   award(userId, BadgeType.STREAK_3,   awarded);
+        if (streak >= 7)   award(userId, BadgeType.STREAK_7,   awarded);
+        if (streak >= 30)  award(userId, BadgeType.STREAK_30,  awarded);
+        if (streak >= 100) award(userId, BadgeType.STREAK_100, awarded);
+
+        if (!awarded.isEmpty()) {
+            checkQuriMaster(userId);
+        }
+    }
+
+    //  트리거 2: 로드맵 전체 완료
+    //  체크 대상: ROADMAP_1, ROADMAP_3
+    @Async
+    @Transactional
+    public void checkAndAwardOnRoadmapComplete(String userId) {
+        List<BadgeType> awarded = new ArrayList<>();
+
+        long completedRoadmaps = roadmapRepository.countByUserIdAndIsCompletedTrue(userId);
+
+        if (completedRoadmaps >= 1) award(userId, BadgeType.ROADMAP_1, awarded);
+        if (completedRoadmaps >= 3) award(userId, BadgeType.ROADMAP_3, awarded);
+
+        if (!awarded.isEmpty()) {
+            checkQuriMaster(userId);
+        }
+    }
+
+    //  트리거 3: 게시글 최초 작성
+    //  체크 대상: FIRST_POST
+    @Async
+    @Transactional
+    public void checkAndAwardOnFirstPost(String userId) {
+        List<BadgeType> awarded = new ArrayList<>();
+        award(userId, BadgeType.FIRST_POST, awarded);
+        if (!awarded.isEmpty()) {
+            checkQuriMaster(userId);
+        }
+    }
+
+    // 뱃지 1개 부여 시도
+    // 이미 보유 중이면 skip
+    private void award(String userId, BadgeType type, List<BadgeType> awarded) {
+        if (badgeRepository.existsByUserIdAndBadgeType(userId, type)) {
+            return;
+        }
+        try {
+            badgeRepository.save(Badge.of(userId, type));
+            awarded.add(type);
+            log.info("뱃지 부여: userId={}, badge={}", userId, type);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("뱃지 UK 충돌 무시: userId={}, badge={}", userId, type);
+        }
+    }
+
+    // QURI_MASTER 조건 확인
+    // REQUIRED_FOR_MASTER 의 뱃지를 전부 보유하면 QURI_MASTER 부여
+    private void checkQuriMaster(String userId) {
+        if (badgeRepository.existsByUserIdAndBadgeType(userId, BadgeType.QURI_MASTER)) {
+            return;
+        }
+        Set<BadgeType> owned = new HashSet<>(badgeRepository.findBadgeTypesByUserId(userId));
+        if (owned.containsAll(REQUIRED_FOR_MASTER)) {
+            try {
+                badgeRepository.save(Badge.of(userId, BadgeType.QURI_MASTER));
+                log.info("QURI_MASTER 달성: userId={}", userId);
+            } catch (DataIntegrityViolationException e) {
+                log.debug("QURI_MASTER UK 충돌 무시: userId={}", userId);
+            }
+        }
+    }
+
+    // 연속 학습 스트릭 계산
+
+    /**
+     * learning_history.completed_at 을 KST LocalDate 로 변환 후
+     * 오늘(또는 어제)부터 역방향으로 연속된 날 수를 카운트한다.
+     *
+     * - 오늘 완료한 강좌가 있으면 오늘부터 역산
+     * - 오늘 완료 강좌가 없고 어제 있으면 어제부터 역산 (당일 미학습 허용)
+     * - 그 외 경우(마지막 학습이 2일 이상 전) 스트릭 = 0
+     */
+    private int calculateStreak(String userId) {
+        List<LocalDateTime> completedDateTimes =
+                learningHistoryRepository.findCompletedAtByUserIdOrderByDesc(userId);
+
+        if (completedDateTimes.isEmpty()) return 0;
+
+        // KST 저장 기준 LocalDate 변환 후 중복 제거, 내림차순 정렬
+        List<LocalDate> dates = completedDateTimes.stream()
+                .map(LocalDateTime::toLocalDate)// DB가 KST 저장이므로 그냥 toLocalDate()
+                .distinct()
+                .sorted((a, b) -> b.compareTo(a))
+                .toList();
+
+        LocalDate today = LocalDate.now(KST);
+        LocalDate mostRecent = dates.get(0);
+
+        // 마지막 학습이 오늘도 어제도 아니면 스트릭 없음
+        if (!mostRecent.equals(today) && !mostRecent.equals(today.minusDays(1))) {
+            return 0;
+        }
+
+        // 가장 최근 날짜부터 역산하며 연속 일수 카운트
+        int streak = 0;
+        LocalDate expected = mostRecent;
+
+        for (LocalDate date : dates) {
+            if (date.equals(expected)) {
+                streak++;
+                expected = expected.minusDays(1);
+            } else {
+                break;
+            }
+        }
+
+        return streak;
+    }
+}

--- a/src/main/java/com/example/kuriq/service/CourseReviewService.java
+++ b/src/main/java/com/example/kuriq/service/CourseReviewService.java
@@ -1,0 +1,146 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.review.ReviewDto;
+import com.example.kuriq.entity.review.CourseReview;
+import com.example.kuriq.entity.review.CourseReviewLike;
+import com.example.kuriq.entity.user.User;
+import com.example.kuriq.repository.review.CourseReviewLikeRepository;
+import com.example.kuriq.repository.review.CourseReviewRepository;
+import com.example.kuriq.repository.roadmap.LearningHistoryRepository;
+import com.example.kuriq.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseReviewService {
+
+    private final CourseReviewRepository reviewRepository;
+    private final CourseReviewLikeRepository reviewLikeRepository;
+    private final LearningHistoryRepository learningHistoryRepository; // 이수 여부 검증용
+    private final UserRepository userRepository;
+
+    // 강좌 평점 요약 조회
+    public ReviewDto.SummaryResponse getSummary(String courseId) {
+        Double avg = reviewRepository.calculateAverageRating(courseId);
+        long count = reviewRepository.countByCourseIdAndIsDeletedFalse(courseId);
+
+        // 소수점 1자리 반올림
+        double averageRating = avg != null ? Math.round(avg * 10.0) / 10.0 : 0.0;
+        return ReviewDto.SummaryResponse.builder()
+                .averageRating(averageRating)
+                .reviewCount(count)
+                .build();
+    }
+
+    // 리뷰 목록 조회
+    public ReviewDto.PageResponse getReviews(String courseId, String userId, int page, int size) {
+        Page<CourseReview> reviewPage = reviewRepository
+                .findByCourseIdAndIsDeletedFalseOrderByCreatedAtDesc(courseId, PageRequest.of(page, size));
+
+        List<String> userIds = reviewPage.getContent().stream().map(CourseReview::getUserId).distinct().toList();
+        Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getName));
+
+        List<ReviewDto.ReviewResponse> content = reviewPage.getContent().stream()
+                .map(r -> {
+                    boolean likedByMe = userId != null &&
+                            reviewLikeRepository.existsByReviewIdAndUserId(r.getId(), userId);
+                    return ReviewDto.ReviewResponse.from(r, nameMap.getOrDefault(r.getUserId(), "알 수 없음"), likedByMe);
+                })
+                .toList();
+
+        return ReviewDto.PageResponse.builder()
+                .content(content)
+                .currentPage(reviewPage.getNumber())
+                .totalPages(reviewPage.getTotalPages())
+                .totalElements(reviewPage.getTotalElements())
+                .hasNext(reviewPage.hasNext())
+                .build();
+    }
+
+    // 리뷰 작성
+    @Transactional
+    public ReviewDto.ReviewResponse createReview(String userId, String courseId, ReviewDto.CreateRequest req) {
+        // 이수 여부 검증 — learning_history에 userId + courseId 존재 여부 확인
+        if (!learningHistoryRepository.existsByUserIdAndCourseId(userId, courseId)) {
+            throw new IllegalStateException("강좌를 이수한 후 리뷰를 작성할 수 있어요.");
+        }
+
+        // 1인 1리뷰 중복 체크
+        if (reviewRepository.existsByUserIdAndCourseIdAndIsDeletedFalse(userId, courseId)) {
+            throw new IllegalStateException("이미 리뷰를 작성한 강좌입니다.");
+        }
+
+        CourseReview review = CourseReview.builder()
+                .userId(userId)
+                .courseId(courseId)
+                .rating(req.getRating())
+                .content(req.getContent())
+                .priorKnowledge(req.getPriorKnowledge())
+                .difficultyMatch(req.getDifficultyMatch())
+                .build();
+        reviewRepository.save(review);
+
+        String authorName = userRepository.findById(userId).map(User::getName).orElse("알 수 없음");
+        return ReviewDto.ReviewResponse.from(review, authorName, false);
+    }
+
+    // 내 리뷰 수정
+    @Transactional
+    public ReviewDto.ReviewResponse updateMyReview(String userId, String courseId, ReviewDto.UpdateRequest req) {
+        CourseReview review = reviewRepository.findByUserIdAndCourseIdAndIsDeletedFalse(userId, courseId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+        review.update(req.getRating(), req.getContent(), req.getPriorKnowledge(), req.getDifficultyMatch());
+        String authorName = userRepository.findById(userId).map(User::getName).orElse("알 수 없음");
+        return ReviewDto.ReviewResponse.from(review, authorName, false);
+    }
+
+    // 내 리뷰 삭제
+    @Transactional
+    public void deleteMyReview(String userId, String courseId) {
+        CourseReview review = reviewRepository.findByUserIdAndCourseIdAndIsDeletedFalse(userId, courseId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+        review.softDelete();
+        // 평균 별점 재계산은 DB 집계 쿼리(calculateAverageRating)가 매번 호출 시 처리함
+    }
+
+    // 리뷰 좋아요 토글
+    @Transactional
+    public ReviewDto.LikeResponse toggleLike(String userId, String reviewId) {
+        CourseReview review = reviewRepository.findById(reviewId)
+                .filter(r -> !r.isDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+        if (reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)) {
+            reviewLikeRepository.findByReviewIdAndUserId(reviewId, userId)
+                    .ifPresent(reviewLikeRepository::delete);
+            review.decreaseLikeCount();
+            return ReviewDto.LikeResponse.builder().liked(false).likeCount(review.getLikeCount()).build();
+        } else {
+            reviewLikeRepository.save(CourseReviewLike.builder()
+                    .reviewId(reviewId).userId(userId).build());
+            review.increaseLikeCount();
+            return ReviewDto.LikeResponse.builder().liked(true).likeCount(review.getLikeCount()).build();
+        }
+    }
+
+    // 내 리뷰 목록
+    public List<ReviewDto.ReviewResponse> getMyReviews(String userId) {
+        List<CourseReview> reviews = reviewRepository
+                .findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId);
+        String authorName = userRepository.findById(userId).map(User::getName).orElse("알 수 없음");
+        return reviews.stream()
+                .map(r -> ReviewDto.ReviewResponse.from(r, authorName, false))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/kuriq/service/PostService.java
+++ b/src/main/java/com/example/kuriq/service/PostService.java
@@ -1,0 +1,219 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.dto.post.PostDto;
+import com.example.kuriq.entity.post.Post;
+import com.example.kuriq.entity.post.PostComment;
+import com.example.kuriq.entity.post.PostLike;
+import com.example.kuriq.entity.user.User;
+import com.example.kuriq.repository.post.PostCommentRepository;
+import com.example.kuriq.repository.post.PostLikeRepository;
+import com.example.kuriq.repository.post.PostRepository;
+import com.example.kuriq.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final PostCommentRepository postCommentRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final UserRepository userRepository;
+
+    // 게시글 목록 조회
+    // 최신순 (기본)
+    public List<PostDto.SummaryResponse> getPostsLatest(int page, int size) {
+        List<Post> posts = postRepository.findByIsDeletedFalseOrderByCreatedAtDesc(
+                PageRequest.of(page, size));
+        return buildSummaryList(posts);
+    }
+
+    // 댓글많은순 (같은 댓글 수면 최신순)
+    public List<PostDto.SummaryResponse> getPostsByComment(int page, int size) {
+        List<Post> posts = postRepository.findByIsDeletedFalseOrderByCommentCountDescCreatedAtDesc(
+                PageRequest.of(page, size));
+        return buildSummaryList(posts);
+    }
+
+    // 목록 응답 빌드 — 작성자 이름 일괄 조회
+    private List<PostDto.SummaryResponse> buildSummaryList(List<Post> posts) {
+        List<String> userIds = posts.stream().map(Post::getUserId).distinct().toList();
+        Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getName));
+
+        return posts.stream()
+                .map(p -> PostDto.SummaryResponse.from(p, nameMap.getOrDefault(p.getUserId(), "알 수 없음")))
+                .toList();
+    }
+
+    // 게시글 상세 조회
+    @Transactional
+    public PostDto.DetailResponse getPost(String postId, String userId) {
+        Post post = getPostOrThrow(postId);
+
+        // 조회수 증가 — 중복 방지 로직은 컨트롤러 또는 세션 기반으로 처리
+        post.increaseViewCount();
+
+        // 작성자 이름
+        String authorName = userRepository.findById(post.getUserId())
+                .map(User::getName).orElse("알 수 없음");
+
+        // 본인 좋아요 여부
+        boolean likedByMe = userId != null && postLikeRepository.existsByPostIdAndUserId(postId, userId);
+
+        // 댓글 목록 빌드
+        List<PostDto.CommentResponse> comments = buildCommentTree(postId);
+
+        return PostDto.DetailResponse.from(post, authorName, likedByMe, comments);
+    }
+
+    // 최상위 댓글 + 대댓글 조합
+    private List<PostDto.CommentResponse> buildCommentTree(String postId) {
+        List<PostComment> all = postCommentRepository.findByPostIdOrderByCreatedAtAsc(postId);
+
+        // 작성자 이름 일괄 조회
+        List<String> userIds = all.stream().map(PostComment::getUserId).distinct().toList();
+        Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getName));
+
+        // 최상위 댓글만 필터 → 각 댓글의 대댓글 목록 붙이기
+        return all.stream()
+                .filter(c -> c.getParentId() == null)
+                .map(c -> {
+                    List<PostDto.CommentResponse> replies = all.stream()
+                            .filter(r -> c.getId().equals(r.getParentId()))
+                            .map(r -> PostDto.CommentResponse.from(r, nameMap.getOrDefault(r.getUserId(), "알 수 없음"), List.of()))
+                            .toList();
+                    return PostDto.CommentResponse.from(c, nameMap.getOrDefault(c.getUserId(), "알 수 없음"), replies);
+                })
+                .toList();
+    }
+
+    // 게시글 작성
+    @Transactional
+    public PostDto.SummaryResponse createPost(String userId, PostDto.CreateRequest req) {
+        Post post = Post.builder()
+                .userId(userId)
+                .title(req.getTitle())
+                .content(req.getContent())
+                .build();
+        postRepository.save(post);
+
+        String authorName = userRepository.findById(userId)
+                .map(User::getName).orElse("알 수 없음");
+        return PostDto.SummaryResponse.from(post, authorName);
+    }
+
+    // 게시글 수정
+    @Transactional
+    public PostDto.SummaryResponse updatePost(String userId, String postId, PostDto.UpdateRequest req) {
+        Post post = getPostOrThrow(postId);
+        validateOwner(post.getUserId(), userId); // 본인 확인
+
+        post.update(req.getTitle(), req.getContent());
+        String authorName = userRepository.findById(userId).map(User::getName).orElse("알 수 없음");
+        return PostDto.SummaryResponse.from(post, authorName);
+    }
+
+    // 게시글 삭제
+    @Transactional
+    public void deletePost(String userId, String postId) {
+        Post post = getPostOrThrow(postId);
+        validateOwner(post.getUserId(), userId);
+        post.softDelete();
+    }
+
+    // 좋아요 토글
+    @Transactional
+    public PostDto.LikeResponse toggleLike(String userId, String postId) {
+        Post post = getPostOrThrow(postId);
+
+        if (postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
+            // 좋아요 취소
+            postLikeRepository.findByPostIdAndUserId(postId, userId)
+                    .ifPresent(postLikeRepository::delete);
+            post.decreaseLikeCount();
+            return PostDto.LikeResponse.builder().liked(false).likeCount(post.getLikeCount()).build();
+        } else {
+            // 좋아요 추가
+            postLikeRepository.save(PostLike.builder()
+                    .postId(postId).userId(userId).build());
+            post.increaseLikeCount();
+            return PostDto.LikeResponse.builder().liked(true).likeCount(post.getLikeCount()).build();
+        }
+    }
+
+    // 댓글 작성
+    @Transactional
+    public PostDto.CommentResponse createComment(String userId, String postId,
+                                                 PostDto.CommentCreateRequest req) {
+        Post post = getPostOrThrow(postId);
+
+        // 대댓글인 경우 부모 댓글 확인
+        if (req.getParentId() != null) {
+            PostComment parent = postCommentRepository.findByIdAndIsDeletedFalse(req.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("부모 댓글을 찾을 수 없습니다."));
+
+            // 대댓글에는 다시 답글 불가 (1단계 제한)
+            if (parent.getParentId() != null) {
+                throw new IllegalArgumentException("대댓글에는 답글을 달 수 없습니다.");
+            }
+        }
+
+        PostComment comment = PostComment.builder()
+                .postId(postId)
+                .userId(userId)
+                .parentId(req.getParentId())
+                .content(req.getContent())
+                .build();
+        postCommentRepository.save(comment);
+        post.increaseCommentCount(); // 댓글 수 증가
+
+        String authorName = userRepository.findById(userId).map(User::getName).orElse("알 수 없음");
+        return PostDto.CommentResponse.from(comment, authorName, List.of());
+    }
+
+    // 댓글 수정
+    @Transactional
+    public PostDto.CommentResponse updateComment(String userId, String commentId,
+                                                 PostDto.CommentUpdateRequest req) {
+        PostComment comment = postCommentRepository.findByIdAndIsDeletedFalse(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        validateOwner(comment.getUserId(), userId);
+
+        comment.update(req.getContent());
+        String authorName = userRepository.findById(userId).map(User::getName).orElse("알 수 없음");
+        return PostDto.CommentResponse.from(comment, authorName, List.of());
+    }
+
+    // 댓글 삭제
+    @Transactional
+    public void deleteComment(String userId, String commentId) {
+        PostComment comment = postCommentRepository.findByIdAndIsDeletedFalse(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        validateOwner(comment.getUserId(), userId);
+
+        // 소프트 삭제 — 내용 "삭제된 댓글입니다."로 대체, commentCount 감소 없음
+        comment.softDelete();
+    }
+
+    private Post getPostOrThrow(String postId) {
+        return postRepository.findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+    }
+
+    // 본인 확인 — 타인이면 403
+    private void validateOwner(String ownerId, String requestUserId) {
+        if (!ownerId.equals(requestUserId)) {
+            throw new SecurityException("본인의 게시글/댓글만 수정·삭제할 수 있습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/service/PostService.java
+++ b/src/main/java/com/example/kuriq/service/PostService.java
@@ -10,6 +10,7 @@ import com.example.kuriq.repository.post.PostLikeRepository;
 import com.example.kuriq.repository.post.PostRepository;
 import com.example.kuriq.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,29 +31,37 @@ public class PostService {
 
     // 게시글 목록 조회
     // 최신순 (기본)
-    public List<PostDto.SummaryResponse> getPostsLatest(int page, int size) {
-        List<Post> posts = postRepository.findByIsDeletedFalseOrderByCreatedAtDesc(
+    public PostDto.PageResponse getPostsLatest(int page, int size) {
+        Page<Post> posts = postRepository.findByIsDeletedFalseOrderByCreatedAtDesc(
                 PageRequest.of(page, size));
-        return buildSummaryList(posts);
+        return buildPageResponse(posts);
     }
 
     // 댓글많은순 (같은 댓글 수면 최신순)
-    public List<PostDto.SummaryResponse> getPostsByComment(int page, int size) {
-        List<Post> posts = postRepository.findByIsDeletedFalseOrderByCommentCountDescCreatedAtDesc(
+    public PostDto.PageResponse getPostsByComment(int page, int size) {
+        Page<Post> posts = postRepository.findByIsDeletedFalseOrderByCommentCountDescCreatedAtDesc(
                 PageRequest.of(page, size));
-        return buildSummaryList(posts);
+        return buildPageResponse(posts);
     }
 
-    // 목록 응답 빌드 — 작성자 이름 일괄 조회
-    private List<PostDto.SummaryResponse> buildSummaryList(List<Post> posts) {
-        List<String> userIds = posts.stream().map(Post::getUserId).distinct().toList();
-        Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
-                .collect(Collectors.toMap(User::getId, User::getName));
+// 페이지 응답 빌드
+private PostDto.PageResponse buildPageResponse(Page<Post> posts) {
+    List<String> userIds = posts.getContent().stream().map(Post::getUserId).distinct().toList();
+    Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
+            .collect(Collectors.toMap(User::getId, User::getName));
 
-        return posts.stream()
-                .map(p -> PostDto.SummaryResponse.from(p, nameMap.getOrDefault(p.getUserId(), "알 수 없음")))
-                .toList();
-    }
+    List<PostDto.SummaryResponse> content = posts.getContent().stream()
+            .map(p -> PostDto.SummaryResponse.from(p, nameMap.getOrDefault(p.getUserId(), "알 수 없음")))
+            .toList();
+
+    return PostDto.PageResponse.builder()
+            .content(content)
+            .currentPage(posts.getNumber())
+            .totalPages(posts.getTotalPages())
+            .totalElements(posts.getTotalElements())
+            .hasNext(posts.hasNext())
+            .build();
+}
 
     // 게시글 상세 조회
     @Transactional

--- a/src/main/java/com/example/kuriq/service/PostService.java
+++ b/src/main/java/com/example/kuriq/service/PostService.java
@@ -28,6 +28,7 @@ public class PostService {
     private final PostCommentRepository postCommentRepository;
     private final PostLikeRepository postLikeRepository;
     private final UserRepository userRepository;
+    private final BadgeService badgeService; // ★ 추가
 
     // 게시글 목록 조회
     // 최신순 (기본)
@@ -44,24 +45,24 @@ public class PostService {
         return buildPageResponse(posts);
     }
 
-// 페이지 응답 빌드
-private PostDto.PageResponse buildPageResponse(Page<Post> posts) {
-    List<String> userIds = posts.getContent().stream().map(Post::getUserId).distinct().toList();
-    Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
-            .collect(Collectors.toMap(User::getId, User::getName));
+    // 페이지 응답 빌드
+    private PostDto.PageResponse buildPageResponse(Page<Post> posts) {
+        List<String> userIds = posts.getContent().stream().map(Post::getUserId).distinct().toList();
+        Map<String, String> nameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getName));
 
-    List<PostDto.SummaryResponse> content = posts.getContent().stream()
-            .map(p -> PostDto.SummaryResponse.from(p, nameMap.getOrDefault(p.getUserId(), "알 수 없음")))
-            .toList();
+        List<PostDto.SummaryResponse> content = posts.getContent().stream()
+                .map(p -> PostDto.SummaryResponse.from(p, nameMap.getOrDefault(p.getUserId(), "알 수 없음")))
+                .toList();
 
-    return PostDto.PageResponse.builder()
-            .content(content)
-            .currentPage(posts.getNumber())
-            .totalPages(posts.getTotalPages())
-            .totalElements(posts.getTotalElements())
-            .hasNext(posts.hasNext())
-            .build();
-}
+        return PostDto.PageResponse.builder()
+                .content(content)
+                .currentPage(posts.getNumber())
+                .totalPages(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .hasNext(posts.hasNext())
+                .build();
+    }
 
     // 게시글 상세 조회
     @Transactional
@@ -115,6 +116,9 @@ private PostDto.PageResponse buildPageResponse(Page<Post> posts) {
                 .content(req.getContent())
                 .build();
         postRepository.save(post);
+
+        // 첫 게시글 작성 뱃지 체크 (비동기)
+        badgeService.checkAndAwardOnFirstPost(userId);
 
         String authorName = userRepository.findById(userId)
                 .map(User::getName).orElse("알 수 없음");

--- a/src/main/java/com/example/kuriq/service/RoadmapService.java
+++ b/src/main/java/com/example/kuriq/service/RoadmapService.java
@@ -33,6 +33,7 @@ public class RoadmapService {
     private final NotificationSettingRepository notificationSettingRepository;
     private final UserRepository userRepository;
     private final EmailService emailService;
+    private final BadgeService badgeService;
     private static final String DASHBOARD_URL = "https://kuriq.com/dashboard";
 
     // 로드맵 생성
@@ -226,8 +227,11 @@ public class RoadmapService {
         }
 
         // 전체 완료 체크
+        boolean roadmapJustCompleted = false;
+
         if (item.getRoadmap().allItemsCompleted()) {
             item.getRoadmap().complete();
+            roadmapJustCompleted = true;
             log.info("로드맵 전체 완료: roadmapId={}", item.getRoadmap().getId());
 
             // 완료 축하 알림 (로드맵 전체 완료 시에만 발송)
@@ -241,6 +245,19 @@ public class RoadmapService {
                         }
                     });
         }
+
+        // 뱃지 체크 — @Async 이므로 현재 트랜잭션과 분리되어 실행됨
+        final boolean finalRoadmapJustCompleted = roadmapJustCompleted;
+        org.springframework.transaction.support.TransactionSynchronizationManager
+                .registerSynchronization(new org.springframework.transaction.support.TransactionSynchronizationAdapter() {
+                    @Override
+                    public void afterCommit() {
+                        badgeService.checkAndAwardOnCourseComplete(userId);
+                        if (finalRoadmapJustCompleted) {
+                            badgeService.checkAndAwardOnRoadmapComplete(userId);
+                        }
+                    }
+                });
 
         return RoadmapResponse.RoadmapItemResponse.from(item);
     }
@@ -299,9 +316,7 @@ public class RoadmapService {
         return courseId.substring(courseId.indexOf("_") + 1);
     }
 
-    /******************************************************************************/
-
-    // 엔티티 → 응답 DTO 변환
+    // 엔티티 -> 응답 DTO 변환
     private RoadmapResponse buildRoadmapResponse(Roadmap roadmap) {
         List<RoadmapItem> items = roadmap.getItems() != null ? roadmap.getItems() : List.of();
         List<RoadmapWeek> weeks = roadmap.getWeeks() != null ? roadmap.getWeeks() : List.of();


### PR DESCRIPTION
## 구현 내용

### 게시판
- 게시글 목록 조회 (최신순 / 댓글많은순)
- 게시글 작성 / 상세 조회 / 수정 / 소프트 삭제
- 댓글 · 대댓글 작성 / 수정 / 소프트 삭제 (1단계 제한)
- 게시글 좋아요 토글
- 비로그인 조회 가능, 작성/수정/삭제는 로그인 필요

### 수강 후기 & 평점
- 리뷰 작성 / 수정 / 삭제
- 리뷰 목록 조회 및 평점 요약 조회

### 뱃지
- 뱃지 구현
- 강좌 완료 시 SEEDLING / COURSE / STREAK 자동 체크
- 로드맵 전체 완료 시 ROADMAP 자동 체크
- 게시글 최초 작성 시 FIRST_POST 자동 부여
- 전체 뱃지 달성 시 QURI_MASTER 자동 부여
- @Async + afterCommit 으로 트랜잭션 커밋 후 비동기 처리

### 공통
- 페이지네이션 공통 적용 (page=0 기준, size=20)

## 관련 이슈
closes #24