### PR TITLE
fix: upsert roadmap courses and keep AI roadmap titles

### DIFF
--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -29,6 +29,7 @@ public class AiClient {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RoadmapGenerateAiResponse {
+        private String title;
         private String goal;
         private int totalWeeks;
         private int weeklyHours;

--- a/src/main/java/com/example/kuriq/dto/roadmap/response/RoadmapResponse.java
+++ b/src/main/java/com/example/kuriq/dto/roadmap/response/RoadmapResponse.java
@@ -30,6 +30,8 @@ public class RoadmapResponse {
 
     private String id;  // 로드맵 id
 
+    private String title;  // 간략화된 로드맵 제목
+
     private String goal;  // 사용자의 학습 목표
 
     private String prompt;  // AI 생성에 사용된 원본 프롬프트

--- a/src/main/java/com/example/kuriq/entity/roadmap/Platform.java
+++ b/src/main/java/com/example/kuriq/entity/roadmap/Platform.java
@@ -1,13 +1,13 @@
 package com.example.kuriq.entity.roadmap;
 
 // 큐릭이 수집하는 공공 교육 플랫폼 종류
-// ERD의 platform_enum과 동일
+// ERD 의 platform_enum 과 동일
 // Course, CourseClickLog 등 플랫폼을 다루는 곳에서 공통으로 사용하기 때문에 별도 파일로 분리했음
 public enum Platform {
     K_MOOC,     // 한국형 온라인 공개강좌 (K-MOOC)
     KOCW,       // 대학 공개강의 서비스 (KOCW)
-    LLL_PORTAL, // 온국민평생배움터
+    LLL_PORTAL, // 온국민평생배움터 (all.go.kr)
+    EVERLEARNING, // 에버러닝 (everlearning.sen.go.kr)
     SEOUL_LLL,  // 서울시 평생학습포털
-    ALLGO,      // 온국민평생배움터 (all.go.kr)
     KURIQ_TEST  // 테스트용 플랫폼
 }

--- a/src/main/java/com/example/kuriq/entity/roadmap/Roadmap.java
+++ b/src/main/java/com/example/kuriq/entity/roadmap/Roadmap.java
@@ -59,6 +59,10 @@ public class Roadmap {
     @Column(nullable = false, length = 500)
     private String goal;
 
+    // 화면에 표시할 간단한 제목
+    @Column(length = 120)
+    private String title;
+
     //  전체 학습 기간 (주 단위)
     @Column(nullable = false)
     private Integer totalWeeks;
@@ -124,11 +128,12 @@ public class Roadmap {
     }
 
     // 로드맵 생성 메서드
-    public static Roadmap create(String userId, String prompt, String goal,
+    public static Roadmap create(String userId, String prompt, String title, String goal,
                                  int totalWeeks, int weeklyHours, int totalCourses) {
         Roadmap r = new Roadmap();
         r.userId = userId;
         r.prompt = prompt;
+        r.title = title;
         r.goal = goal;
         r.totalWeeks = totalWeeks;
         r.weeklyHours = weeklyHours;

--- a/src/main/java/com/example/kuriq/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kuriq/exception/GlobalExceptionHandler.java
@@ -41,8 +41,24 @@ public class GlobalExceptionHandler {
     // DB 제약조건 위반 에러 처리 -> 이미 softDelete된 이메일로 회원가입 시 409가 아닌 500 에러 던지는 문제 해결
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, String>> handleDataIntegrity(DataIntegrityViolationException e) {
+        String rootMessage = e.getMostSpecificCause() != null
+                ? e.getMostSpecificCause().getMessage()
+                : e.getMessage();
+
+        if (rootMessage != null) {
+            if (rootMessage.contains("uk_platform_course")) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Map.of("error", "COURSE_DUPLICATE", "message", "이미 등록된 강좌입니다."));
+            }
+
+            if (rootMessage.contains("users") || rootMessage.contains("email")) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Map.of("error", "EMAIL_DUPLICATE", "message", "이미 사용 중인 이메일입니다."));
+            }
+        }
+
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(Map.of("message", "이미 사용 중인 이메일입니다."));
+                .body(Map.of("error", "DATA_INTEGRITY_VIOLATION", "message", "데이터 저장 중 충돌이 발생했습니다."));
     }
 
     @ExceptionHandler(ApiException.class)

--- a/src/main/java/com/example/kuriq/repository/roadmap/CourseRepository.java
+++ b/src/main/java/com/example/kuriq/repository/roadmap/CourseRepository.java
@@ -4,6 +4,9 @@ import com.example.kuriq.entity.roadmap.Course;
 import com.example.kuriq.entity.roadmap.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +16,74 @@ public interface CourseRepository extends JpaRepository<Course, String>, JpaSpec
 
     // 플랫폼 + 플랫폼 강좌 ID로 조회 (크롤링 시 중복 방지용)
     Optional<Course> findByPlatformAndPlatformCourseId(Platform platform, String platformCourseId);
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO courses (
+            id,
+            platform,
+            platform_course_id,
+            title,
+            institution,
+            category,
+            difficulty,
+            duration_weeks,
+            estimated_hours,
+            has_certificate,
+            url,
+            description,
+            is_active,
+            last_crawled_at,
+            created_at,
+            updated_at
+        ) VALUES (
+            :id,
+            :platform,
+            :platformCourseId,
+            :title,
+            :institution,
+            :category,
+            :difficulty,
+            :durationWeeks,
+            :estimatedHours,
+            :hasCertificate,
+            :url,
+            :description,
+            :isActive,
+            :lastCrawledAt,
+            NOW(),
+            NOW()
+        )
+        ON DUPLICATE KEY UPDATE
+            title = VALUES(title),
+            institution = VALUES(institution),
+            category = VALUES(category),
+            difficulty = VALUES(difficulty),
+            duration_weeks = VALUES(duration_weeks),
+            estimated_hours = VALUES(estimated_hours),
+            has_certificate = VALUES(has_certificate),
+            url = VALUES(url),
+            description = VALUES(description),
+            is_active = VALUES(is_active),
+            last_crawled_at = VALUES(last_crawled_at),
+            updated_at = NOW()
+        """, nativeQuery = true)
+    void upsertCourse(
+            @Param("id") String id,
+            @Param("platform") String platform,
+            @Param("platformCourseId") String platformCourseId,
+            @Param("title") String title,
+            @Param("institution") String institution,
+            @Param("category") String category,
+            @Param("difficulty") String difficulty,
+            @Param("durationWeeks") Integer durationWeeks,
+            @Param("estimatedHours") java.math.BigDecimal estimatedHours,
+            @Param("hasCertificate") Boolean hasCertificate,
+            @Param("url") String url,
+            @Param("description") String description,
+            @Param("isActive") Boolean isActive,
+            @Param("lastCrawledAt") java.time.LocalDateTime lastCrawledAt
+    );
 
     // 활성화된 강좌만 조회
     List<Course> findByIsActiveTrue();

--- a/src/main/java/com/example/kuriq/service/RoadmapService.java
+++ b/src/main/java/com/example/kuriq/service/RoadmapService.java
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Service;
 
 import org.springframework.data.domain.Pageable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -61,21 +63,17 @@ public class RoadmapService {
         List<String> missingIds = new java.util.ArrayList<>();
         
         for (String courseId : courseIds) {
-            String[] parts = courseId.split("_", 2);
-            if (parts.length != 2) {
+            Platform platform = extractPlatformFromCourseId(courseId);
+            String platformCourseId = extractPlatformCourseId(courseId);
+
+            if (platform == null || platformCourseId == null || platformCourseId.isBlank()) {
                 log.warn("[RoadmapService] 잘못된 courseId 형식: {}", courseId);
+                missingIds.add(courseId);
                 continue;
             }
-            String platformStr = parts[0];
-            String platformCourseId = parts[1];
-            
-            try {
-                Platform platform = Platform.valueOf(platformStr.replace("-", "_"));
-                courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId)
-                        .ifPresent(course -> courseMap.put(courseId, course));
-            } catch (IllegalArgumentException e) {
-                log.warn("[RoadmapService] 잘못된 platform: {}", platformStr);
-            }
+
+            courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId)
+                    .ifPresent(course -> courseMap.put(courseId, course));
             
             // 없는 강좌는 목록에 추가
             if (!courseMap.containsKey(courseId)) {
@@ -93,39 +91,36 @@ public class RoadmapService {
             AiClient.CourseMetadataResponse metadataResponse = aiClient.getCourseMetadata(missingIds);
             if (metadataResponse != null && metadataResponse.getCourses() != null) {
                 for (AiClient.CourseMetadataResponse.CourseMetadataDto dto : metadataResponse.getCourses()) {
-                    // chromaDB 데이터로 Course 객체 생성 (ID 는 DB 에서 자동 생성)
-                    Course chromaCourse = Course.builder()
-                            .title(dto.getTitle())
-                            .platform(parsePlatform(dto.getPlatform()))
-                            .platformCourseId(extractPlatformCourseId(dto.getCourseId()))
-                            .institution(dto.getInstitution())
-                            .category(dto.getCategory())
-                            .difficulty(dto.getDifficulty())
-                            .durationWeeks(dto.getDurationWeeks() != null ? dto.getDurationWeeks() : 0)
-                            .estimatedHours(dto.getEstimatedHours() != null ? java.math.BigDecimal.valueOf(dto.getEstimatedHours()) : java.math.BigDecimal.ZERO)
-                            .hasCertificate(dto.getHasCertificate() != null ? dto.getHasCertificate() : false)
-                            .url(dto.getUrl() != null && !dto.getUrl().isEmpty() ? dto.getUrl() : "#")
-                            .isActive(true)
-                            .build();
-                    
-                    // DB 에 저장 (중복이면 기존 것 사용)
-                    try {
-                        courseRepository.save(chromaCourse);
-                        // 저장 후 생성된 ID 로 courseMap 업데이트
-                        courseMap.put(dto.getCourseId(), chromaCourse);
-                        log.info("[RoadmapService] Course 저장 완료: {} (UUID: {})", dto.getCourseId(), chromaCourse.getId());
-                    } catch (Exception e) {
-                        log.warn("[RoadmapService] Course 저장 실패 (중복), 기존 강좌 조회: {}", dto.getCourseId());
-                        // 이미 있으면 다시 조회
-                        courseRepository.findByPlatformAndPlatformCourseId(chromaCourse.getPlatform(), chromaCourse.getPlatformCourseId())
-                                .ifPresentOrElse(
-                                        existing -> {
-                                            courseMap.put(dto.getCourseId(), existing);
-                                            log.info("[RoadmapService] 기존 강좌 사용: {} (UUID: {})", dto.getCourseId(), existing.getId());
-                                        },
-                                        () -> log.error("[RoadmapService] 강좌를 찾을 수 없음: {}", dto.getCourseId())
-                                );
-                    }
+                    Platform platform = parsePlatform(dto.getPlatform());
+                    String platformCourseId = extractPlatformCourseId(dto.getCourseId());
+                    BigDecimal estimatedHours = dto.getEstimatedHours() != null
+                            ? BigDecimal.valueOf(dto.getEstimatedHours())
+                            : BigDecimal.ZERO;
+
+                    courseRepository.upsertCourse(
+                            UUID.randomUUID().toString(),
+                            platform.name(),
+                            platformCourseId,
+                            dto.getTitle(),
+                            dto.getInstitution(),
+                            dto.getCategory(),
+                            dto.getDifficulty(),
+                            dto.getDurationWeeks() != null ? dto.getDurationWeeks() : 0,
+                            estimatedHours,
+                            dto.getHasCertificate() != null ? dto.getHasCertificate() : false,
+                            dto.getUrl() != null && !dto.getUrl().isEmpty() ? dto.getUrl() : "#",
+                            null,
+                            true,
+                            LocalDateTime.now());
+
+                    courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId)
+                            .ifPresentOrElse(
+                                    saved -> {
+                                        courseMap.put(dto.getCourseId(), saved);
+                                        log.info("[RoadmapService] Course upsert 완료: {} (UUID: {})", dto.getCourseId(), saved.getId());
+                                    },
+                                    () -> log.error("[RoadmapService] upsert 후에도 강좌를 찾을 수 없음: {}", dto.getCourseId())
+                            );
                 }
                 log.info("[RoadmapService] chromaDB 에서 {}개 강좌 메타데이터 조회 및 저장 완료", metadataResponse.getCourses().size());
             }
@@ -144,7 +139,7 @@ public class RoadmapService {
 
         // 로드맵 저장 (초기 상태: inactive)
         Roadmap roadmap = Roadmap.create(
-                userId, prompt, ai.getGoal(),
+                userId, prompt, buildRoadmapTitle(prompt, ai.getGoal(), ai.getTitle()), ai.getGoal(),
                 ai.getTotalWeeks(), ai.getWeeklyHours(), totalCourses);
         roadmapRepository.save(roadmap);
 
@@ -309,20 +304,75 @@ try {
         if (platformStr == null || platformStr.isBlank()) {
             return Platform.K_MOOC;  // 기본값
         }
+        
+        // 한국어 플랫폼명 매핑
+        if ("온국민평생배움터".equals(platformStr) || "ALLGO".equals(platformStr)) {
+            return Platform.LLL_PORTAL;
+        }
+        if ("에버러닝".equals(platformStr)) {
+            return Platform.EVERLEARNING;
+        }
+        
+        // 영문 플랫폼명 (언더스코어/대시 정규화)
+        String normalized = platformStr.replace("-", "_").toUpperCase();
         try {
-            return Platform.valueOf(platformStr.replace("-", "_").toUpperCase());
+            return Platform.valueOf(normalized);
         } catch (IllegalArgumentException e) {
             log.warn("[RoadmapService] 잘못된 platform: {}, 기본값 사용", platformStr);
             return Platform.K_MOOC;
         }
     }
 
-    private String extractPlatformCourseId(String courseId) {
-        if (courseId == null || !courseId.contains("_")) {
-            return courseId;
+    private Platform extractPlatformFromCourseId(String courseId) {
+        if (courseId == null || courseId.isBlank()) {
+            return null;
         }
-        // "K-MOOC_19921" → "19921"
-        return courseId.substring(courseId.indexOf("_") + 1);
+
+        for (Platform platform : Platform.values()) {
+            String prefix = platform.name() + "_";
+            if (courseId.startsWith(prefix)) {
+                return platform;
+            }
+        }
+
+        // 레거시/한글 포맷 호환
+        if (courseId.startsWith("K-MOOC_")) {
+            return Platform.K_MOOC;
+        }
+        if (courseId.startsWith("에버러닝_")) {
+            return Platform.EVERLEARNING;
+        }
+        if (courseId.startsWith("온국민평생배움터_")) {
+            return Platform.LLL_PORTAL;
+        }
+        if (courseId.startsWith("KOCW_")) {
+            return Platform.KOCW;
+        }
+
+        return null;
+    }
+
+    private String extractPlatformCourseId(String courseId) {
+        Platform platform = extractPlatformFromCourseId(courseId);
+        if (platform != null) {
+            String prefix = platform.name() + "_";
+            if (courseId.startsWith(prefix)) {
+                return courseId.substring(prefix.length());
+            }
+        }
+
+        // 레거시/한글 포맷 호환
+        if (courseId != null && courseId.startsWith("K-MOOC_")) {
+            return courseId.substring("K-MOOC_".length());
+        }
+        if (courseId != null && courseId.startsWith("에버러닝_")) {
+            return courseId.substring("에버러닝_".length());
+        }
+        if (courseId != null && courseId.startsWith("온국민평생배움터_")) {
+            return courseId.substring("온국민평생배움터_".length());
+        }
+
+        return courseId;
     }
 
     // 엔티티 -> 응답 DTO 변환
@@ -357,6 +407,7 @@ try {
 
         return RoadmapResponse.builder()
                 .id(roadmap.getId())
+                .title(roadmap.getTitle())
                 .goal(roadmap.getGoal())
                 .prompt(roadmap.getPrompt())
                 .totalWeeks(roadmap.getTotalWeeks())
@@ -371,5 +422,46 @@ try {
                 .completedAt(roadmap.getCompletedAt())
                 .weeks(weekResponses)
                 .build();
+    }
+
+    private String buildRoadmapTitle(String prompt, String goal, String aiTitle) {
+        if (aiTitle != null && !aiTitle.isBlank()) {
+            return aiTitle;
+        }
+
+        String source = ((prompt == null ? "" : prompt) + " " + (goal == null ? "" : goal)).toLowerCase();
+
+        String subject = "맞춤 학습";
+        if (containsAny(source, "ai", "인공지능", "데이터", "머신러닝", "딥러닝")) subject = "AI·데이터";
+        else if (containsAny(source, "영어")) subject = "영어";
+        else if (containsAny(source, "일본어")) subject = "일본어";
+        else if (containsAny(source, "중국어")) subject = "중국어";
+        else if (containsAny(source, "파이썬")) subject = "파이썬";
+        else if (containsAny(source, "프로그래밍", "코딩", "개발")) subject = "프로그래밍";
+        else if (containsAny(source, "디자인", "ui", "ux")) subject = "디자인";
+        else if (containsAny(source, "마케팅")) subject = "마케팅";
+        else if (containsAny(source, "경영", "비즈니스")) subject = "경영";
+        else if (containsAny(source, "회계", "재무")) subject = "회계·재무";
+        else if (containsAny(source, "통계")) subject = "통계";
+        else if (containsAny(source, "글쓰기")) subject = "글쓰기";
+
+        String level = "";
+        if (containsAny(source, "심화")) level = "심화";
+        else if (containsAny(source, "중급")) level = "중급";
+        else if (containsAny(source, "초급")) level = "초급";
+        else if (containsAny(source, "입문", "처음", "기초")) level = "입문";
+
+        return level.isBlank()
+                ? subject + " 로드맵"
+                : subject + " " + level + " 로드맵";
+    }
+
+    private boolean containsAny(String text, String... keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- store AI-generated roadmap titles in backend responses and persisted roadmap data
- upsert roadmap course metadata to avoid duplicate course insert conflicts during roadmap generation
- return data-integrity errors with constraint-specific messages instead of always reporting duplicate email