### PR TITLE
장소추천 API에 카페 전용 조회와 카카오 페이징을 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 src/main/resources/application.properties
+src/main/resources/application-local.properties

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -29,6 +29,7 @@ public class AiClient {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RoadmapGenerateAiResponse {
+        private String title;
         private String goal;
         private int totalWeeks;
         private int weeklyHours;

--- a/src/main/java/com/example/kuriq/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/kuriq/client/KakaoLocalClient.java
@@ -34,22 +34,26 @@ public class KakaoLocalClient {
     @Value("${kakao.local.rest-api-key:}")
     private String kakaoRestApiKey;
 
+    @Value("${oauth.kakao.client-id:}")
+    private String kakaoOauthClientId;
+
     public List<KakaoPlace> searchNearbyPrivateSpaces(double lat, double lng, int radius, int limit) {
         if (limit <= 0) {
             return List.of();
         }
 
-        if (!StringUtils.hasText(kakaoRestApiKey)) {
-            log.warn("Kakao Local REST API key is not configured. Returning only public study spaces.");
+        String effectiveApiKey = resolveKakaoApiKey();
+        if (!StringUtils.hasText(effectiveApiKey)) {
+            log.warn("Kakao Local REST API key is not configured. Set KAKAO_LOCAL_REST_API_KEY or oauth.kakao.client-id. Returning only public study spaces.");
             return List.of();
         }
 
         Map<String, KakaoPlace> deduplicated = new LinkedHashMap<>();
 
-        safeFetchByCategory(lng, lat, radius, Math.min(limit, API_MAX_SIZE))
+        safeFetchByCategory(effectiveApiKey, lng, lat, radius, Math.min(limit, API_MAX_SIZE))
                 .forEach(place -> deduplicated.putIfAbsent(place.id(), place));
 
-        safeFetchByKeyword(STUDY_CAFE_KEYWORD, lng, lat, radius, Math.min(limit, API_MAX_SIZE))
+        safeFetchByKeyword(effectiveApiKey, STUDY_CAFE_KEYWORD, lng, lat, radius, Math.min(limit, API_MAX_SIZE))
                 .forEach(place -> deduplicated.putIfAbsent(place.id(), place));
 
         return deduplicated.values().stream()
@@ -58,8 +62,8 @@ public class KakaoLocalClient {
                 .toList();
     }
 
-    private List<KakaoPlace> fetchByCategory(double lng, double lat, int radius, int size) {
-        return get()
+    private List<KakaoPlace> fetchByCategory(String apiKey, double lng, double lat, int radius, int size) {
+        return get(apiKey)
                 .uri(uriBuilder -> uriBuilder
                         .path(SEARCH_BY_CATEGORY_PATH)
                         .queryParam("category_group_code", CAFE_CATEGORY_GROUP_CODE)
@@ -76,8 +80,8 @@ public class KakaoLocalClient {
                 .orElseGet(List::of);
     }
 
-    private List<KakaoPlace> fetchByKeyword(String keyword, double lng, double lat, int radius, int size) {
-        return get()
+    private List<KakaoPlace> fetchByKeyword(String apiKey, String keyword, double lng, double lat, int radius, int size) {
+        return get(apiKey)
                 .uri(uriBuilder -> uriBuilder
                         .path(SEARCH_BY_KEYWORD_PATH)
                         .queryParam("query", keyword)
@@ -94,30 +98,46 @@ public class KakaoLocalClient {
                 .orElseGet(List::of);
     }
 
-    private List<KakaoPlace> safeFetchByCategory(double lng, double lat, int radius, int size) {
+    private List<KakaoPlace> safeFetchByCategory(String apiKey, double lng, double lat, int radius, int size) {
         try {
-            return fetchByCategory(lng, lat, radius, size);
+            return fetchByCategory(apiKey, lng, lat, radius, size);
         } catch (Exception e) {
             log.warn("Failed to fetch Kakao category places: {}", e.getMessage());
             return List.of();
         }
     }
 
-    private List<KakaoPlace> safeFetchByKeyword(String keyword, double lng, double lat, int radius, int size) {
+    private List<KakaoPlace> safeFetchByKeyword(String apiKey, String keyword, double lng, double lat, int radius, int size) {
         try {
-            return fetchByKeyword(keyword, lng, lat, radius, size);
+            return fetchByKeyword(apiKey, keyword, lng, lat, radius, size);
         } catch (Exception e) {
             log.warn("Failed to fetch Kakao keyword places: {}", e.getMessage());
             return List.of();
         }
     }
 
-    private WebClient.RequestHeadersUriSpec<?> get() {
+    private WebClient.RequestHeadersUriSpec<?> get(String apiKey) {
         return webClientBuilder
                 .baseUrl(kakaoLocalBaseUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + apiKey)
                 .build()
                 .get();
+    }
+
+    private String resolveKakaoApiKey() {
+        if (isUsableKey(kakaoRestApiKey)) {
+            return kakaoRestApiKey;
+        }
+
+        if (isUsableKey(kakaoOauthClientId)) {
+            return kakaoOauthClientId;
+        }
+
+        return "";
+    }
+
+    private boolean isUsableKey(String value) {
+        return StringUtils.hasText(value) && !value.startsWith("your-");
     }
 
     private record KakaoLocalSearchResponse(List<KakaoPlace> documents) {

--- a/src/main/java/com/example/kuriq/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/kuriq/client/KakaoLocalClient.java
@@ -1,0 +1,150 @@
+package com.example.kuriq.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoLocalClient {
+
+    private static final String SEARCH_BY_CATEGORY_PATH = "/v2/local/search/category.json";
+    private static final String SEARCH_BY_KEYWORD_PATH = "/v2/local/search/keyword.json";
+    private static final String CAFE_CATEGORY_GROUP_CODE = "CE7";
+    private static final String STUDY_CAFE_KEYWORD = "스터디카페";
+    private static final int API_MAX_SIZE = 15;
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${kakao.local.base-url:https://dapi.kakao.com}")
+    private String kakaoLocalBaseUrl;
+
+    @Value("${kakao.local.rest-api-key:}")
+    private String kakaoRestApiKey;
+
+    public List<KakaoPlace> searchNearbyPrivateSpaces(double lat, double lng, int radius, int limit) {
+        if (limit <= 0) {
+            return List.of();
+        }
+
+        if (!StringUtils.hasText(kakaoRestApiKey)) {
+            log.warn("Kakao Local REST API key is not configured. Returning only public study spaces.");
+            return List.of();
+        }
+
+        Map<String, KakaoPlace> deduplicated = new LinkedHashMap<>();
+
+        safeFetchByCategory(lng, lat, radius, Math.min(limit, API_MAX_SIZE))
+                .forEach(place -> deduplicated.putIfAbsent(place.id(), place));
+
+        safeFetchByKeyword(STUDY_CAFE_KEYWORD, lng, lat, radius, Math.min(limit, API_MAX_SIZE))
+                .forEach(place -> deduplicated.putIfAbsent(place.id(), place));
+
+        return deduplicated.values().stream()
+                .sorted(Comparator.comparingInt(KakaoPlace::distanceMeters))
+                .limit(limit)
+                .toList();
+    }
+
+    private List<KakaoPlace> fetchByCategory(double lng, double lat, int radius, int size) {
+        return get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(SEARCH_BY_CATEGORY_PATH)
+                        .queryParam("category_group_code", CAFE_CATEGORY_GROUP_CODE)
+                        .queryParam("x", lng)
+                        .queryParam("y", lat)
+                        .queryParam("radius", radius)
+                        .queryParam("size", size)
+                        .queryParam("sort", "distance")
+                        .build())
+                .retrieve()
+                .bodyToMono(KakaoLocalSearchResponse.class)
+                .blockOptional(REQUEST_TIMEOUT)
+                .map(KakaoLocalSearchResponse::documents)
+                .orElseGet(List::of);
+    }
+
+    private List<KakaoPlace> fetchByKeyword(String keyword, double lng, double lat, int radius, int size) {
+        return get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(SEARCH_BY_KEYWORD_PATH)
+                        .queryParam("query", keyword)
+                        .queryParam("x", lng)
+                        .queryParam("y", lat)
+                        .queryParam("radius", radius)
+                        .queryParam("size", size)
+                        .queryParam("sort", "distance")
+                        .build())
+                .retrieve()
+                .bodyToMono(KakaoLocalSearchResponse.class)
+                .blockOptional(REQUEST_TIMEOUT)
+                .map(KakaoLocalSearchResponse::documents)
+                .orElseGet(List::of);
+    }
+
+    private List<KakaoPlace> safeFetchByCategory(double lng, double lat, int radius, int size) {
+        try {
+            return fetchByCategory(lng, lat, radius, size);
+        } catch (Exception e) {
+            log.warn("Failed to fetch Kakao category places: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private List<KakaoPlace> safeFetchByKeyword(String keyword, double lng, double lat, int radius, int size) {
+        try {
+            return fetchByKeyword(keyword, lng, lat, radius, size);
+        } catch (Exception e) {
+            log.warn("Failed to fetch Kakao keyword places: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private WebClient.RequestHeadersUriSpec<?> get() {
+        return webClientBuilder
+                .baseUrl(kakaoLocalBaseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey)
+                .build()
+                .get();
+    }
+
+    private record KakaoLocalSearchResponse(List<KakaoPlace> documents) {
+    }
+
+    public record KakaoPlace(
+            String id,
+            String place_name,
+            String category_name,
+            String phone,
+            String address_name,
+            String road_address_name,
+            String x,
+            String y,
+            String place_url,
+            String distance
+    ) {
+        public int distanceMeters() {
+            try {
+                return distance == null ? Integer.MAX_VALUE : Integer.parseInt(distance);
+            } catch (NumberFormatException e) {
+                return Integer.MAX_VALUE;
+            }
+        }
+
+        public String resolvedAddress() {
+            return StringUtils.hasText(road_address_name) ? road_address_name : address_name;
+        }
+    }
+}

--- a/src/main/java/com/example/kuriq/client/KakaoLocalClient.java
+++ b/src/main/java/com/example/kuriq/client/KakaoLocalClient.java
@@ -9,6 +9,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,6 +25,7 @@ public class KakaoLocalClient {
     private static final String CAFE_CATEGORY_GROUP_CODE = "CE7";
     private static final String STUDY_CAFE_KEYWORD = "스터디카페";
     private static final int API_MAX_SIZE = 15;
+    private static final int API_MAX_PAGE = 45;
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
 
     private final WebClient.Builder webClientBuilder;
@@ -50,10 +52,10 @@ public class KakaoLocalClient {
 
         Map<String, KakaoPlace> deduplicated = new LinkedHashMap<>();
 
-        safeFetchByCategory(effectiveApiKey, lng, lat, radius, Math.min(limit, API_MAX_SIZE))
+        fetchCategoryPages(effectiveApiKey, lng, lat, radius, limit)
                 .forEach(place -> deduplicated.putIfAbsent(place.id(), place));
 
-        safeFetchByKeyword(effectiveApiKey, STUDY_CAFE_KEYWORD, lng, lat, radius, Math.min(limit, API_MAX_SIZE))
+        fetchKeywordPages(effectiveApiKey, STUDY_CAFE_KEYWORD, lng, lat, radius, limit)
                 .forEach(place -> deduplicated.putIfAbsent(place.id(), place));
 
         return deduplicated.values().stream()
@@ -62,7 +64,34 @@ public class KakaoLocalClient {
                 .toList();
     }
 
-    private List<KakaoPlace> fetchByCategory(String apiKey, double lng, double lat, int radius, int size) {
+    private List<KakaoPlace> fetchCategoryPages(String apiKey, double lng, double lat, int radius, int limit) {
+        return fetchPages(page -> safeFetchByCategory(apiKey, lng, lat, radius, API_MAX_SIZE, page), limit);
+    }
+
+    private List<KakaoPlace> fetchKeywordPages(String apiKey, String keyword, double lng, double lat, int radius, int limit) {
+        return fetchPages(page -> safeFetchByKeyword(apiKey, keyword, lng, lat, radius, API_MAX_SIZE, page), limit);
+    }
+
+    private List<KakaoPlace> fetchPages(PageFetcher fetcher, int limit) {
+        List<KakaoPlace> results = new ArrayList<>();
+
+        for (int page = 1; page <= API_MAX_PAGE && results.size() < limit; page++) {
+            KakaoLocalSearchResponse response = fetcher.fetch(page);
+            if (response == null || response.documents() == null || response.documents().isEmpty()) {
+                break;
+            }
+
+            results.addAll(response.documents());
+
+            if (response.meta() == null || Boolean.TRUE.equals(response.meta().is_end())) {
+                break;
+            }
+        }
+
+        return results.stream().limit(limit).toList();
+    }
+
+    private KakaoLocalSearchResponse fetchByCategory(String apiKey, double lng, double lat, int radius, int size, int page) {
         return get(apiKey)
                 .uri(uriBuilder -> uriBuilder
                         .path(SEARCH_BY_CATEGORY_PATH)
@@ -71,16 +100,16 @@ public class KakaoLocalClient {
                         .queryParam("y", lat)
                         .queryParam("radius", radius)
                         .queryParam("size", size)
+                        .queryParam("page", page)
                         .queryParam("sort", "distance")
                         .build())
                 .retrieve()
                 .bodyToMono(KakaoLocalSearchResponse.class)
                 .blockOptional(REQUEST_TIMEOUT)
-                .map(KakaoLocalSearchResponse::documents)
-                .orElseGet(List::of);
+                .orElse(null);
     }
 
-    private List<KakaoPlace> fetchByKeyword(String apiKey, String keyword, double lng, double lat, int radius, int size) {
+    private KakaoLocalSearchResponse fetchByKeyword(String apiKey, String keyword, double lng, double lat, int radius, int size, int page) {
         return get(apiKey)
                 .uri(uriBuilder -> uriBuilder
                         .path(SEARCH_BY_KEYWORD_PATH)
@@ -89,30 +118,30 @@ public class KakaoLocalClient {
                         .queryParam("y", lat)
                         .queryParam("radius", radius)
                         .queryParam("size", size)
+                        .queryParam("page", page)
                         .queryParam("sort", "distance")
                         .build())
                 .retrieve()
                 .bodyToMono(KakaoLocalSearchResponse.class)
                 .blockOptional(REQUEST_TIMEOUT)
-                .map(KakaoLocalSearchResponse::documents)
-                .orElseGet(List::of);
+                .orElse(null);
     }
 
-    private List<KakaoPlace> safeFetchByCategory(String apiKey, double lng, double lat, int radius, int size) {
+    private KakaoLocalSearchResponse safeFetchByCategory(String apiKey, double lng, double lat, int radius, int size, int page) {
         try {
-            return fetchByCategory(apiKey, lng, lat, radius, size);
+            return fetchByCategory(apiKey, lng, lat, radius, size, page);
         } catch (Exception e) {
             log.warn("Failed to fetch Kakao category places: {}", e.getMessage());
-            return List.of();
+            return null;
         }
     }
 
-    private List<KakaoPlace> safeFetchByKeyword(String apiKey, String keyword, double lng, double lat, int radius, int size) {
+    private KakaoLocalSearchResponse safeFetchByKeyword(String apiKey, String keyword, double lng, double lat, int radius, int size, int page) {
         try {
-            return fetchByKeyword(apiKey, keyword, lng, lat, radius, size);
+            return fetchByKeyword(apiKey, keyword, lng, lat, radius, size, page);
         } catch (Exception e) {
             log.warn("Failed to fetch Kakao keyword places: {}", e.getMessage());
-            return List.of();
+            return null;
         }
     }
 
@@ -140,7 +169,15 @@ public class KakaoLocalClient {
         return StringUtils.hasText(value) && !value.startsWith("your-");
     }
 
-    private record KakaoLocalSearchResponse(List<KakaoPlace> documents) {
+    private record KakaoLocalSearchResponse(KakaoLocalMeta meta, List<KakaoPlace> documents) {
+    }
+
+    private record KakaoLocalMeta(Boolean is_end) {
+    }
+
+    @FunctionalInterface
+    private interface PageFetcher {
+        KakaoLocalSearchResponse fetch(int page);
     }
 
     public record KakaoPlace(

--- a/src/main/java/com/example/kuriq/controller/StudySpaceController.java
+++ b/src/main/java/com/example/kuriq/controller/StudySpaceController.java
@@ -1,6 +1,7 @@
 package com.example.kuriq.controller;
 
 import com.example.kuriq.dto.space.response.StudySpaceResponse;
+import com.example.kuriq.entity.space.StudySpace;
 import com.example.kuriq.service.StudySpaceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -45,9 +46,12 @@ public class StudySpaceController {
             @Parameter(description = "검색 반경(m). 기본 2000, 최대 10000", example = "2000")
             @RequestParam(required = false) @Min(value = 1, message = "반경은 1m 이상이어야 합니다") Integer radius,
 
+            @Parameter(description = "공간 유형 필터(optional): LIBRARY, LIFELONG_LEARNING, FIFTY_PLUS, YOUTH_CENTER, CAFE")
+            @RequestParam(required = false) StudySpace.SpaceType type,
+
             // JWT 인증에서 추출한 userId — 인증 확인 용도 (실제 조회에는 미사용)
             @AuthenticationPrincipal String userId
     ) {
-        return ResponseEntity.ok(studySpaceService.getNearbySpaces(lat, lng, radius));
+        return ResponseEntity.ok(studySpaceService.getNearbySpaces(lat, lng, radius, type));
     }
 }

--- a/src/main/java/com/example/kuriq/controller/StudySpaceController.java
+++ b/src/main/java/com/example/kuriq/controller/StudySpaceController.java
@@ -32,8 +32,7 @@ public class StudySpaceController {
     // 현재 위치 기반으로 주변 학습 공간을 거리순으로 최대 20개 반환
     @Operation(
             summary = "주변 학습 공간 조회",
-            description = "현재 위치(위도/경도) 기준 반경 내 학습 공간을 거리순으로 반환합니다. " +
-                    "공공 공간(도서관/평생학습관/50플러스)이 3개 미만이면 카페를 보조로 추가합니다. 최대 20개."
+            description = "현재 위치(위도/경도) 기준 반경 내 학습 공간을 거리순으로 반환합니다. 최대 20개."
     )
     @GetMapping("/nearby")
     public ResponseEntity<List<StudySpaceResponse>> getNearbySpaces(
@@ -43,7 +42,7 @@ public class StudySpaceController {
             @Parameter(description = "현재 위치 경도", example = "127.0473", required = true)
             @RequestParam double lng,
 
-            @Parameter(description = "검색 반경(m). 기본 2000, 최대 5000", example = "2000")
+            @Parameter(description = "검색 반경(m). 기본 2000, 최대 10000", example = "2000")
             @RequestParam(required = false) @Min(value = 1, message = "반경은 1m 이상이어야 합니다") Integer radius,
 
             // JWT 인증에서 추출한 userId — 인증 확인 용도 (실제 조회에는 미사용)

--- a/src/main/java/com/example/kuriq/dto/roadmap/response/RoadmapResponse.java
+++ b/src/main/java/com/example/kuriq/dto/roadmap/response/RoadmapResponse.java
@@ -30,6 +30,8 @@ public class RoadmapResponse {
 
     private String id;  // 로드맵 id
 
+    private String title;  // 간략화된 로드맵 제목
+
     private String goal;  // 사용자의 학습 목표
 
     private String prompt;  // AI 생성에 사용된 원본 프롬프트

--- a/src/main/java/com/example/kuriq/dto/space/response/StudySpaceResponse.java
+++ b/src/main/java/com/example/kuriq/dto/space/response/StudySpaceResponse.java
@@ -16,7 +16,7 @@ public class StudySpaceResponse {
     @Schema(description = "공간 이름", example = "강남구립 논현도서관")
     private String name;
 
-    // LIBRARY / LIFELONG_LEARNING / FIFTY_PLUS / CAFE 중 하나
+    // LIBRARY / LIFELONG_LEARNING / FIFTY_PLUS / YOUTH_CENTER / CAFE 중 하나
     @Schema(description = "공간 유형", example = "LIBRARY")
     private String type;
 

--- a/src/main/java/com/example/kuriq/entity/roadmap/Platform.java
+++ b/src/main/java/com/example/kuriq/entity/roadmap/Platform.java
@@ -1,13 +1,13 @@
 package com.example.kuriq.entity.roadmap;
 
 // 큐릭이 수집하는 공공 교육 플랫폼 종류
-// ERD의 platform_enum과 동일
+// ERD 의 platform_enum 과 동일
 // Course, CourseClickLog 등 플랫폼을 다루는 곳에서 공통으로 사용하기 때문에 별도 파일로 분리했음
 public enum Platform {
     K_MOOC,     // 한국형 온라인 공개강좌 (K-MOOC)
     KOCW,       // 대학 공개강의 서비스 (KOCW)
-    LLL_PORTAL, // 온국민평생배움터
+    LLL_PORTAL, // 온국민평생배움터 (all.go.kr)
+    EVERLEARNING, // 에버러닝 (everlearning.sen.go.kr)
     SEOUL_LLL,  // 서울시 평생학습포털
-    ALLGO,      // 온국민평생배움터 (all.go.kr)
     KURIQ_TEST  // 테스트용 플랫폼
 }

--- a/src/main/java/com/example/kuriq/entity/roadmap/Roadmap.java
+++ b/src/main/java/com/example/kuriq/entity/roadmap/Roadmap.java
@@ -59,6 +59,10 @@ public class Roadmap {
     @Column(nullable = false, length = 500)
     private String goal;
 
+    // 화면에 표시할 간단한 제목
+    @Column(length = 120)
+    private String title;
+
     //  전체 학습 기간 (주 단위)
     @Column(nullable = false)
     private Integer totalWeeks;
@@ -124,11 +128,12 @@ public class Roadmap {
     }
 
     // 로드맵 생성 메서드
-    public static Roadmap create(String userId, String prompt, String goal,
+    public static Roadmap create(String userId, String prompt, String title, String goal,
                                  int totalWeeks, int weeklyHours, int totalCourses) {
         Roadmap r = new Roadmap();
         r.userId = userId;
         r.prompt = prompt;
+        r.title = title;
         r.goal = goal;
         r.totalWeeks = totalWeeks;
         r.weeklyHours = weeklyHours;

--- a/src/main/java/com/example/kuriq/entity/space/StudySpace.java
+++ b/src/main/java/com/example/kuriq/entity/space/StudySpace.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
         name = "study_spaces",
         indexes = {
                 @Index(name = "idx_spaces_location", columnList = "latitude, longitude"),
-                @Index(name = "idx_spaces_type'", columnList = "type"),
+                @Index(name = "idx_spaces_type", columnList = "type"),
                 @Index(name = "idx_spaces_active", columnList = "isActive"), // TODO: DB 컬럼명으로 교체 고려
         }
 )
@@ -82,6 +82,7 @@ public class StudySpace {
         LIBRARY,
         LIFELONG_LEARNING,
         FIFTY_PLUS,
+        YOUTH_CENTER,
         CAFE
     }
 }

--- a/src/main/java/com/example/kuriq/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kuriq/exception/GlobalExceptionHandler.java
@@ -41,8 +41,24 @@ public class GlobalExceptionHandler {
     // DB 제약조건 위반 에러 처리 -> 이미 softDelete된 이메일로 회원가입 시 409가 아닌 500 에러 던지는 문제 해결
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, String>> handleDataIntegrity(DataIntegrityViolationException e) {
+        String rootMessage = e.getMostSpecificCause() != null
+                ? e.getMostSpecificCause().getMessage()
+                : e.getMessage();
+
+        if (rootMessage != null) {
+            if (rootMessage.contains("uk_platform_course")) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Map.of("error", "COURSE_DUPLICATE", "message", "이미 등록된 강좌입니다."));
+            }
+
+            if (rootMessage.contains("users") || rootMessage.contains("email")) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Map.of("error", "EMAIL_DUPLICATE", "message", "이미 사용 중인 이메일입니다."));
+            }
+        }
+
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(Map.of("message", "이미 사용 중인 이메일입니다."));
+                .body(Map.of("error", "DATA_INTEGRITY_VIOLATION", "message", "데이터 저장 중 충돌이 발생했습니다."));
     }
 
     @ExceptionHandler(ApiException.class)

--- a/src/main/java/com/example/kuriq/repository/roadmap/CourseRepository.java
+++ b/src/main/java/com/example/kuriq/repository/roadmap/CourseRepository.java
@@ -4,6 +4,9 @@ import com.example.kuriq.entity.roadmap.Course;
 import com.example.kuriq.entity.roadmap.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +16,74 @@ public interface CourseRepository extends JpaRepository<Course, String>, JpaSpec
 
     // 플랫폼 + 플랫폼 강좌 ID로 조회 (크롤링 시 중복 방지용)
     Optional<Course> findByPlatformAndPlatformCourseId(Platform platform, String platformCourseId);
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO courses (
+            id,
+            platform,
+            platform_course_id,
+            title,
+            institution,
+            category,
+            difficulty,
+            duration_weeks,
+            estimated_hours,
+            has_certificate,
+            url,
+            description,
+            is_active,
+            last_crawled_at,
+            created_at,
+            updated_at
+        ) VALUES (
+            :id,
+            :platform,
+            :platformCourseId,
+            :title,
+            :institution,
+            :category,
+            :difficulty,
+            :durationWeeks,
+            :estimatedHours,
+            :hasCertificate,
+            :url,
+            :description,
+            :isActive,
+            :lastCrawledAt,
+            NOW(),
+            NOW()
+        )
+        ON DUPLICATE KEY UPDATE
+            title = VALUES(title),
+            institution = VALUES(institution),
+            category = VALUES(category),
+            difficulty = VALUES(difficulty),
+            duration_weeks = VALUES(duration_weeks),
+            estimated_hours = VALUES(estimated_hours),
+            has_certificate = VALUES(has_certificate),
+            url = VALUES(url),
+            description = VALUES(description),
+            is_active = VALUES(is_active),
+            last_crawled_at = VALUES(last_crawled_at),
+            updated_at = NOW()
+        """, nativeQuery = true)
+    void upsertCourse(
+            @Param("id") String id,
+            @Param("platform") String platform,
+            @Param("platformCourseId") String platformCourseId,
+            @Param("title") String title,
+            @Param("institution") String institution,
+            @Param("category") String category,
+            @Param("difficulty") String difficulty,
+            @Param("durationWeeks") Integer durationWeeks,
+            @Param("estimatedHours") java.math.BigDecimal estimatedHours,
+            @Param("hasCertificate") Boolean hasCertificate,
+            @Param("url") String url,
+            @Param("description") String description,
+            @Param("isActive") Boolean isActive,
+            @Param("lastCrawledAt") java.time.LocalDateTime lastCrawledAt
+    );
 
     // 활성화된 강좌만 조회
     List<Course> findByIsActiveTrue();

--- a/src/main/java/com/example/kuriq/repository/space/StudySpaceRepository.java
+++ b/src/main/java/com/example/kuriq/repository/space/StudySpaceRepository.java
@@ -31,6 +31,26 @@ public interface StudySpaceRepository extends JpaRepository<StudySpace, String> 
             @Param("radius") int radius
     );
 
+    @Query(value = """
+        SELECT *
+        FROM study_spaces
+        WHERE is_active = true
+          AND type = :type
+          AND (
+            6371000 * acos(
+                cos(radians(:lat)) * cos(radians(latitude))
+                * cos(radians(longitude) - radians(:lng))
+                + sin(radians(:lat)) * sin(radians(latitude))
+            )
+          ) <= :radius
+        """, nativeQuery = true)
+    List<StudySpace> findSpacesNearbyByType(
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("radius") int radius,
+            @Param("type") String type
+    );
+
     // 반경 내 카페만 거리순 조회
     // 공공 공간이 3개 미만일 때 보조로 추가
     @Query(value = """

--- a/src/main/java/com/example/kuriq/service/RoadmapService.java
+++ b/src/main/java/com/example/kuriq/service/RoadmapService.java
@@ -222,32 +222,32 @@ public class RoadmapService {
         }
 
         // 전체 완료 체크
-boolean roadmapJustCompleted = false;
-try {
-    if (item.getRoadmap().allItemsCompleted()) {
-        item.getRoadmap().complete();
-        roadmapJustCompleted = true;
-        log.info("로드맵 전체 완료: roadmapId={}", item.getRoadmap().getId());
-        // 완료 축하 알림 (로드맵 전체 완료 시에만 발송)
-        notificationSettingRepository.findCompletionAlertTarget(userId)
-                .ifPresent(ns -> {
-                    User user = userRepository.findById(userId).orElse(null);
-                    if (user != null && user.getEmail() != null) {
-                        emailService.sendCompletionEmail(
-                                user.getEmail(), userId, user.getName(),
-                                item.getRoadmap().getGoal(), DASHBOARD_URL);
-                    }
-                });
-    }
-} catch (Exception e) {
-    log.error("로드맵 완료 체크 중 오류: {}", e.getMessage(), e);
-}
+        boolean roadmapJustCompleted = false;
+        try {
+            if (item.getRoadmap().allItemsCompleted()) {
+                item.getRoadmap().complete();
+                roadmapJustCompleted = true;
+                log.info("로드맵 전체 완료: roadmapId={}", item.getRoadmap().getId());
+
+                // 완료 축하 알림 (로드맵 전체 완료 시에만 발송)
+                notificationSettingRepository.findCompletionAlertTarget(userId)
+                        .ifPresent(ns -> {
+                            User user = userRepository.findById(userId).orElse(null);
+                            if (user != null && user.getEmail() != null) {
+                                emailService.sendCompletionEmail(
+                                        user.getEmail(), userId, user.getName(),
+                                        item.getRoadmap().getGoal(), DASHBOARD_URL);
+                            }
+                        });
+            }
+        } catch (Exception e) {
+            log.error("로드맵 완료 체크 중 오류: {}", e.getMessage(), e);
         }
 
         // 뱃지 체크 — @Async 이므로 현재 트랜잭션과 분리되어 실행됨
         final boolean finalRoadmapJustCompleted = roadmapJustCompleted;
         org.springframework.transaction.support.TransactionSynchronizationManager
-                .registerSynchronization(new org.springframework.transaction.support.TransactionSynchronizationAdapter() {
+                .registerSynchronization(new org.springframework.transaction.support.TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
                         badgeService.checkAndAwardOnCourseComplete(userId);

--- a/src/main/java/com/example/kuriq/service/RoadmapService.java
+++ b/src/main/java/com/example/kuriq/service/RoadmapService.java
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Service;
 
 import org.springframework.data.domain.Pageable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -61,21 +63,17 @@ public class RoadmapService {
         List<String> missingIds = new java.util.ArrayList<>();
         
         for (String courseId : courseIds) {
-            String[] parts = courseId.split("_", 2);
-            if (parts.length != 2) {
+            Platform platform = extractPlatformFromCourseId(courseId);
+            String platformCourseId = extractPlatformCourseId(courseId);
+
+            if (platform == null || platformCourseId == null || platformCourseId.isBlank()) {
                 log.warn("[RoadmapService] 잘못된 courseId 형식: {}", courseId);
+                missingIds.add(courseId);
                 continue;
             }
-            String platformStr = parts[0];
-            String platformCourseId = parts[1];
-            
-            try {
-                Platform platform = Platform.valueOf(platformStr.replace("-", "_"));
-                courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId)
-                        .ifPresent(course -> courseMap.put(courseId, course));
-            } catch (IllegalArgumentException e) {
-                log.warn("[RoadmapService] 잘못된 platform: {}", platformStr);
-            }
+
+            courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId)
+                    .ifPresent(course -> courseMap.put(courseId, course));
             
             // 없는 강좌는 목록에 추가
             if (!courseMap.containsKey(courseId)) {
@@ -93,39 +91,36 @@ public class RoadmapService {
             AiClient.CourseMetadataResponse metadataResponse = aiClient.getCourseMetadata(missingIds);
             if (metadataResponse != null && metadataResponse.getCourses() != null) {
                 for (AiClient.CourseMetadataResponse.CourseMetadataDto dto : metadataResponse.getCourses()) {
-                    // chromaDB 데이터로 Course 객체 생성 (ID 는 DB 에서 자동 생성)
-                    Course chromaCourse = Course.builder()
-                            .title(dto.getTitle())
-                            .platform(parsePlatform(dto.getPlatform()))
-                            .platformCourseId(extractPlatformCourseId(dto.getCourseId()))
-                            .institution(dto.getInstitution())
-                            .category(dto.getCategory())
-                            .difficulty(dto.getDifficulty())
-                            .durationWeeks(dto.getDurationWeeks() != null ? dto.getDurationWeeks() : 0)
-                            .estimatedHours(dto.getEstimatedHours() != null ? java.math.BigDecimal.valueOf(dto.getEstimatedHours()) : java.math.BigDecimal.ZERO)
-                            .hasCertificate(dto.getHasCertificate() != null ? dto.getHasCertificate() : false)
-                            .url(dto.getUrl() != null && !dto.getUrl().isEmpty() ? dto.getUrl() : "#")
-                            .isActive(true)
-                            .build();
-                    
-                    // DB 에 저장 (중복이면 기존 것 사용)
-                    try {
-                        courseRepository.save(chromaCourse);
-                        // 저장 후 생성된 ID 로 courseMap 업데이트
-                        courseMap.put(dto.getCourseId(), chromaCourse);
-                        log.info("[RoadmapService] Course 저장 완료: {} (UUID: {})", dto.getCourseId(), chromaCourse.getId());
-                    } catch (Exception e) {
-                        log.warn("[RoadmapService] Course 저장 실패 (중복), 기존 강좌 조회: {}", dto.getCourseId());
-                        // 이미 있으면 다시 조회
-                        courseRepository.findByPlatformAndPlatformCourseId(chromaCourse.getPlatform(), chromaCourse.getPlatformCourseId())
-                                .ifPresentOrElse(
-                                        existing -> {
-                                            courseMap.put(dto.getCourseId(), existing);
-                                            log.info("[RoadmapService] 기존 강좌 사용: {} (UUID: {})", dto.getCourseId(), existing.getId());
-                                        },
-                                        () -> log.error("[RoadmapService] 강좌를 찾을 수 없음: {}", dto.getCourseId())
-                                );
-                    }
+                    Platform platform = parsePlatform(dto.getPlatform());
+                    String platformCourseId = extractPlatformCourseId(dto.getCourseId());
+                    BigDecimal estimatedHours = dto.getEstimatedHours() != null
+                            ? BigDecimal.valueOf(dto.getEstimatedHours())
+                            : BigDecimal.ZERO;
+
+                    courseRepository.upsertCourse(
+                            UUID.randomUUID().toString(),
+                            platform.name(),
+                            platformCourseId,
+                            dto.getTitle(),
+                            dto.getInstitution(),
+                            dto.getCategory(),
+                            dto.getDifficulty(),
+                            dto.getDurationWeeks() != null ? dto.getDurationWeeks() : 0,
+                            estimatedHours,
+                            dto.getHasCertificate() != null ? dto.getHasCertificate() : false,
+                            dto.getUrl() != null && !dto.getUrl().isEmpty() ? dto.getUrl() : "#",
+                            null,
+                            true,
+                            LocalDateTime.now());
+
+                    courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId)
+                            .ifPresentOrElse(
+                                    saved -> {
+                                        courseMap.put(dto.getCourseId(), saved);
+                                        log.info("[RoadmapService] Course upsert 완료: {} (UUID: {})", dto.getCourseId(), saved.getId());
+                                    },
+                                    () -> log.error("[RoadmapService] upsert 후에도 강좌를 찾을 수 없음: {}", dto.getCourseId())
+                            );
                 }
                 log.info("[RoadmapService] chromaDB 에서 {}개 강좌 메타데이터 조회 및 저장 완료", metadataResponse.getCourses().size());
             }
@@ -144,7 +139,7 @@ public class RoadmapService {
 
         // 로드맵 저장 (초기 상태: inactive)
         Roadmap roadmap = Roadmap.create(
-                userId, prompt, ai.getGoal(),
+                userId, prompt, buildRoadmapTitle(prompt, ai.getGoal(), ai.getTitle()), ai.getGoal(),
                 ai.getTotalWeeks(), ai.getWeeklyHours(), totalCourses);
         roadmapRepository.save(roadmap);
 
@@ -309,20 +304,75 @@ try {
         if (platformStr == null || platformStr.isBlank()) {
             return Platform.K_MOOC;  // 기본값
         }
+        
+        // 한국어 플랫폼명 매핑
+        if ("온국민평생배움터".equals(platformStr) || "ALLGO".equals(platformStr)) {
+            return Platform.LLL_PORTAL;
+        }
+        if ("에버러닝".equals(platformStr)) {
+            return Platform.EVERLEARNING;
+        }
+        
+        // 영문 플랫폼명 (언더스코어/대시 정규화)
+        String normalized = platformStr.replace("-", "_").toUpperCase();
         try {
-            return Platform.valueOf(platformStr.replace("-", "_").toUpperCase());
+            return Platform.valueOf(normalized);
         } catch (IllegalArgumentException e) {
             log.warn("[RoadmapService] 잘못된 platform: {}, 기본값 사용", platformStr);
             return Platform.K_MOOC;
         }
     }
 
-    private String extractPlatformCourseId(String courseId) {
-        if (courseId == null || !courseId.contains("_")) {
-            return courseId;
+    private Platform extractPlatformFromCourseId(String courseId) {
+        if (courseId == null || courseId.isBlank()) {
+            return null;
         }
-        // "K-MOOC_19921" → "19921"
-        return courseId.substring(courseId.indexOf("_") + 1);
+
+        for (Platform platform : Platform.values()) {
+            String prefix = platform.name() + "_";
+            if (courseId.startsWith(prefix)) {
+                return platform;
+            }
+        }
+
+        // 레거시/한글 포맷 호환
+        if (courseId.startsWith("K-MOOC_")) {
+            return Platform.K_MOOC;
+        }
+        if (courseId.startsWith("에버러닝_")) {
+            return Platform.EVERLEARNING;
+        }
+        if (courseId.startsWith("온국민평생배움터_")) {
+            return Platform.LLL_PORTAL;
+        }
+        if (courseId.startsWith("KOCW_")) {
+            return Platform.KOCW;
+        }
+
+        return null;
+    }
+
+    private String extractPlatformCourseId(String courseId) {
+        Platform platform = extractPlatformFromCourseId(courseId);
+        if (platform != null) {
+            String prefix = platform.name() + "_";
+            if (courseId.startsWith(prefix)) {
+                return courseId.substring(prefix.length());
+            }
+        }
+
+        // 레거시/한글 포맷 호환
+        if (courseId != null && courseId.startsWith("K-MOOC_")) {
+            return courseId.substring("K-MOOC_".length());
+        }
+        if (courseId != null && courseId.startsWith("에버러닝_")) {
+            return courseId.substring("에버러닝_".length());
+        }
+        if (courseId != null && courseId.startsWith("온국민평생배움터_")) {
+            return courseId.substring("온국민평생배움터_".length());
+        }
+
+        return courseId;
     }
 
     // 엔티티 -> 응답 DTO 변환
@@ -357,6 +407,7 @@ try {
 
         return RoadmapResponse.builder()
                 .id(roadmap.getId())
+                .title(roadmap.getTitle())
                 .goal(roadmap.getGoal())
                 .prompt(roadmap.getPrompt())
                 .totalWeeks(roadmap.getTotalWeeks())
@@ -371,5 +422,46 @@ try {
                 .completedAt(roadmap.getCompletedAt())
                 .weeks(weekResponses)
                 .build();
+    }
+
+    private String buildRoadmapTitle(String prompt, String goal, String aiTitle) {
+        if (aiTitle != null && !aiTitle.isBlank()) {
+            return aiTitle;
+        }
+
+        String source = ((prompt == null ? "" : prompt) + " " + (goal == null ? "" : goal)).toLowerCase();
+
+        String subject = "맞춤 학습";
+        if (containsAny(source, "ai", "인공지능", "데이터", "머신러닝", "딥러닝")) subject = "AI·데이터";
+        else if (containsAny(source, "영어")) subject = "영어";
+        else if (containsAny(source, "일본어")) subject = "일본어";
+        else if (containsAny(source, "중국어")) subject = "중국어";
+        else if (containsAny(source, "파이썬")) subject = "파이썬";
+        else if (containsAny(source, "프로그래밍", "코딩", "개발")) subject = "프로그래밍";
+        else if (containsAny(source, "디자인", "ui", "ux")) subject = "디자인";
+        else if (containsAny(source, "마케팅")) subject = "마케팅";
+        else if (containsAny(source, "경영", "비즈니스")) subject = "경영";
+        else if (containsAny(source, "회계", "재무")) subject = "회계·재무";
+        else if (containsAny(source, "통계")) subject = "통계";
+        else if (containsAny(source, "글쓰기")) subject = "글쓰기";
+
+        String level = "";
+        if (containsAny(source, "심화")) level = "심화";
+        else if (containsAny(source, "중급")) level = "중급";
+        else if (containsAny(source, "초급")) level = "초급";
+        else if (containsAny(source, "입문", "처음", "기초")) level = "입문";
+
+        return level.isBlank()
+                ? subject + " 로드맵"
+                : subject + " " + level + " 로드맵";
+    }
+
+    private boolean containsAny(String text, String... keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/example/kuriq/service/StudySpaceService.java
+++ b/src/main/java/com/example/kuriq/service/StudySpaceService.java
@@ -1,5 +1,6 @@
 package com.example.kuriq.service;
 
+import com.example.kuriq.client.KakaoLocalClient;
 import com.example.kuriq.dto.space.response.StudySpaceResponse;
 import com.example.kuriq.entity.space.StudySpace;
 import com.example.kuriq.repository.space.StudySpaceRepository;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,19 +18,19 @@ import java.util.List;
 public class StudySpaceService {
 
     private final StudySpaceRepository studySpaceRepository;
+    private final KakaoLocalClient kakaoLocalClient;
 
-    // 반경 기본값: 2000m / 최대값: 5000m
+    // 반경 기본값: 2000m / 최대값: 10000m
     private static final int DEFAULT_RADIUS = 2000;
-    private static final int MAX_RADIUS     = 5000;
+    private static final int MAX_RADIUS     = 10000;
 
-    // 공공 공간이 이 수 미만이면 카페를 보조로 추가
-    private static final int PUBLIC_SPACE_MIN = 3;
+    private static final int MAX_RESULT_COUNT = 20;
 
     // 위치 기반 주변 학습 공간 조회
     // 처리 순서:
     //   1) 공공 공간(도서관, 평생학습관, 50플러스) 먼저 조회
-    //   2) 공공 공간이 3개 미만이면 카페를 추가로 조회해서 합침
-    //   3) 합친 목록을 거리순으로 재정렬 후 최대 20개 반환
+    //   2) 남는 슬롯만큼 카카오 로컬 API에서 민간 공간(카페/스터디카페) 조회
+    //   3) 공공 공간을 우선 반환하고, 민간 공간은 후순위로 최대 20개까지 반환
     public List<StudySpaceResponse> getNearbySpaces(double lat, double lng, Integer radius) {
 
         // 반경 유효성 처리: null이면 기본값, MAX_RADIUS 초과 시 최대값으로 고정
@@ -36,17 +38,7 @@ public class StudySpaceService {
 
         // 공공 공간 먼저 조회
         List<StudySpace> publicSpaces = studySpaceRepository.findPublicSpacesNearby(lat, lng, effectiveRadius);
-        List<StudySpace> result = new ArrayList<>(publicSpaces);
-
-        // 공공 공간이 기준치 미만이면 카페를 보조로 추가
-        if (publicSpaces.size() < PUBLIC_SPACE_MIN) {
-            List<StudySpace> cafes = studySpaceRepository.findCafesNearby(lat, lng, effectiveRadius);
-            result.addAll(cafes);
-        }
-
-        // 각 공간까지의 거리를 Haversine으로 계산 후 DTO 변환
-        // 공공 + 카페 합쳤을 때 전체 거리순 보장을 위해 재정렬
-        return result.stream()
+        List<StudySpaceResponse> publicResponses = publicSpaces.stream()
                 .map(space -> {
                     double dist = haversine(lat, lng,
                             space.getLatitude().doubleValue(),   // BigDecimal → double
@@ -54,8 +46,35 @@ public class StudySpaceService {
                     return StudySpaceResponse.from(space, dist);
                 })
                 .sorted((a, b) -> Integer.compare(a.getDistanceMeters(), b.getDistanceMeters()))
-                .limit(20) // 최대 20개 제한
+                .limit(MAX_RESULT_COUNT)
                 .toList();
+
+        int remainingSlots = MAX_RESULT_COUNT - publicResponses.size();
+        if (remainingSlots <= 0) {
+            return publicResponses;
+        }
+
+        List<StudySpaceResponse> privateResponses = kakaoLocalClient
+                .searchNearbyPrivateSpaces(lat, lng, effectiveRadius, remainingSlots)
+                .stream()
+                .map(place -> StudySpaceResponse.builder()
+                        .id("kakao:" + place.id())
+                        .name(place.place_name())
+                        .type(StudySpace.SpaceType.CAFE.name())
+                        .address(place.resolvedAddress())
+                        .latitude(new BigDecimal(place.y()))
+                        .longitude(new BigDecimal(place.x()))
+                        .operatingHours(null)
+                        .phone(place.phone())
+                        .hasWifi(null)
+                        .hasPowerOutlet(null)
+                        .distanceMeters(place.distanceMeters())
+                        .build())
+                .toList();
+
+        List<StudySpaceResponse> result = new ArrayList<>(publicResponses);
+        result.addAll(privateResponses);
+        return result;
     }
 
     // Haversine 공식: 두 위경도 좌표 사이의 지표면 거리(미터) 계산

--- a/src/main/java/com/example/kuriq/service/StudySpaceService.java
+++ b/src/main/java/com/example/kuriq/service/StudySpaceService.java
@@ -32,10 +32,23 @@ public class StudySpaceService {
     //   1) 공공 공간(도서관, 평생학습관, 50플러스) 먼저 조회
     //   2) 남는 슬롯만큼 카카오 로컬 API에서 민간 공간(카페/스터디카페) 조회
     //   3) 공공 공간을 우선 반환하고, 민간 공간은 후순위로 최대 20개까지 반환
-    public List<StudySpaceResponse> getNearbySpaces(double lat, double lng, Integer radius) {
+    public List<StudySpaceResponse> getNearbySpaces(double lat, double lng, Integer radius, StudySpace.SpaceType type) {
 
         // 반경 유효성 처리: null이면 기본값, MAX_RADIUS 초과 시 최대값으로 고정
         int effectiveRadius = (radius == null) ? DEFAULT_RADIUS : Math.min(radius, MAX_RADIUS);
+
+        if (type == StudySpace.SpaceType.CAFE) {
+            return getNearbyCafeSpaces(lat, lng, effectiveRadius);
+        }
+
+        if (type != null) {
+            return getStoredSpacesByType(lat, lng, effectiveRadius, type);
+        }
+
+        return getMixedSpaces(lat, lng, effectiveRadius);
+    }
+
+    private List<StudySpaceResponse> getMixedSpaces(double lat, double lng, int effectiveRadius) {
 
         // 공공 공간 먼저 조회
         List<StudySpace> publicSpaces = studySpaceRepository.findPublicSpacesNearby(lat, lng, effectiveRadius);
@@ -82,6 +95,39 @@ public class StudySpaceService {
         List<StudySpaceResponse> result = new ArrayList<>(limitedPublicResponses);
         result.addAll(limitedPrivateResponses);
         return result;
+    }
+
+    private List<StudySpaceResponse> getStoredSpacesByType(double lat, double lng, int effectiveRadius, StudySpace.SpaceType type) {
+        return studySpaceRepository.findSpacesNearbyByType(lat, lng, effectiveRadius, type.name()).stream()
+                .map(space -> toResponse(space, lat, lng))
+                .sorted((a, b) -> Integer.compare(a.getDistanceMeters(), b.getDistanceMeters()))
+                .limit(MAX_RESULT_COUNT)
+                .toList();
+    }
+
+    private List<StudySpaceResponse> getNearbyCafeSpaces(double lat, double lng, int effectiveRadius) {
+        return kakaoLocalClient.searchNearbyPrivateSpaces(lat, lng, effectiveRadius, MAX_RESULT_COUNT).stream()
+                .map(place -> StudySpaceResponse.builder()
+                        .id("kakao:" + place.id())
+                        .name(place.place_name())
+                        .type(StudySpace.SpaceType.CAFE.name())
+                        .address(place.resolvedAddress())
+                        .latitude(new BigDecimal(place.y()))
+                        .longitude(new BigDecimal(place.x()))
+                        .operatingHours(null)
+                        .phone(place.phone())
+                        .hasWifi(null)
+                        .hasPowerOutlet(null)
+                        .distanceMeters(place.distanceMeters())
+                        .build())
+                .toList();
+    }
+
+    private StudySpaceResponse toResponse(StudySpace space, double lat, double lng) {
+        double dist = haversine(lat, lng,
+                space.getLatitude().doubleValue(),
+                space.getLongitude().doubleValue());
+        return StudySpaceResponse.from(space, dist);
     }
 
     // Haversine 공식: 두 위경도 좌표 사이의 지표면 거리(미터) 계산

--- a/src/main/java/com/example/kuriq/service/StudySpaceService.java
+++ b/src/main/java/com/example/kuriq/service/StudySpaceService.java
@@ -25,6 +25,7 @@ public class StudySpaceService {
     private static final int MAX_RADIUS     = 10000;
 
     private static final int MAX_RESULT_COUNT = 20;
+    private static final int MIN_PRIVATE_SPACE_COUNT = 4;
 
     // 위치 기반 주변 학습 공간 조회
     // 처리 순서:
@@ -46,16 +47,17 @@ public class StudySpaceService {
                     return StudySpaceResponse.from(space, dist);
                 })
                 .sorted((a, b) -> Integer.compare(a.getDistanceMeters(), b.getDistanceMeters()))
-                .limit(MAX_RESULT_COUNT)
                 .toList();
 
-        int remainingSlots = MAX_RESULT_COUNT - publicResponses.size();
-        if (remainingSlots <= 0) {
-            return publicResponses;
-        }
+        int privateSlots = Math.min(MIN_PRIVATE_SPACE_COUNT, MAX_RESULT_COUNT);
+        int publicLimit = Math.max(MAX_RESULT_COUNT - privateSlots, 0);
+
+        List<StudySpaceResponse> limitedPublicResponses = publicResponses.stream()
+                .limit(publicLimit)
+                .toList();
 
         List<StudySpaceResponse> privateResponses = kakaoLocalClient
-                .searchNearbyPrivateSpaces(lat, lng, effectiveRadius, remainingSlots)
+                .searchNearbyPrivateSpaces(lat, lng, effectiveRadius, privateSlots)
                 .stream()
                 .map(place -> StudySpaceResponse.builder()
                         .id("kakao:" + place.id())
@@ -72,8 +74,13 @@ public class StudySpaceService {
                         .build())
                 .toList();
 
-        List<StudySpaceResponse> result = new ArrayList<>(publicResponses);
-        result.addAll(privateResponses);
+        int remainingSlots = MAX_RESULT_COUNT - limitedPublicResponses.size();
+        List<StudySpaceResponse> limitedPrivateResponses = privateResponses.stream()
+                .limit(Math.max(remainingSlots, 0))
+                .toList();
+
+        List<StudySpaceResponse> result = new ArrayList<>(limitedPublicResponses);
+        result.addAll(limitedPrivateResponses);
         return result;
     }
 

--- a/src/main/resources/application-local.properties.example
+++ b/src/main/resources/application-local.properties.example
@@ -22,3 +22,7 @@ jwt.refresh-token-expiry=1209600000
 # AI Service
 ai.service.base-url=http://localhost:8000
 internal.api-key=dev-secret
+
+# Kakao Local API
+kakao.local.rest-api-key=${KAKAO_LOCAL_REST_API_KEY:}
+kakao.local.base-url=${KAKAO_LOCAL_BASE_URL:https://dapi.kakao.com}


### PR DESCRIPTION
## 요약
- 장소추천 API에 카페 전용 조회 필터를 추가하고, 카페 탭에서는 카카오 결과를 직접 최대 20개까지 조회하도록 정리했습니다.
- 카카오 Local API의 카테고리/키워드 검색에 페이지 순회를 붙여 10km 반경에서도 일반 카페와 스터디카페 결과를 더 안정적으로 모으도록 보완했습니다.
- 카카오 키가 로컬 환경에서 빠졌을 때를 대비해 fallback 경로를 정리하고, 관련 설정 예시와 gitignore도 함께 보완했습니다.

## 확인한 것
- ./gradlew compileJava