### PR TITLE
feat: 다음 추천 강좌 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0' // swagger
 	implementation 'org.springframework.boot:spring-boot-starter-mail' // 비밀번호 재설정 시 이메일 발송 로직
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis' // Redis
 }

--- a/src/main/java/com/example/kuriq/client/AiClient.java
+++ b/src/main/java/com/example/kuriq/client/AiClient.java
@@ -1,15 +1,13 @@
 package com.example.kuriq.client;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
-import java.util.UUID;
+
 
 @Component
 @RequiredArgsConstructor
@@ -207,6 +205,37 @@ public class AiClient {
         }
     }
 
+    // 다음 추천 요청 DTO
+    // Spring Boot -> AI 서버로 보내는 요청
+    // courseId: 본인 강좌 제외용, category: 벡터 검색 필터, top_k: 후보 수
+    @Getter
+    @Builder
+    public static class RecommendationAiRequest {
+        private String courseId;
+        private String courseTitle;
+        private String category;
+        private int top_k;
+    }
+
+    // 다음 추천 응답 DTO
+    // AI 서버 -> Spring Boot로 오는 응답
+    @Getter
+    @Setter
+    public static class RecommendationAiResponse {
+        private List<RecommendationCourseDto> courses;
+
+        // 추천 강좌 1개
+        @Getter
+        @Setter
+        public static class RecommendationCourseDto {
+            private String course_id;
+            private String title;
+            private String institution;
+            private String category;
+            private String duration;
+        }
+    }
+
     public RoadmapGenerateAiResponse generateRoadmap(RoadmapGenerateAiRequest request) {
         return aiWebClient.post()
                 .uri("/internal/ai/roadmap/generate")
@@ -320,10 +349,24 @@ public class AiClient {
                 .block(Duration.ofSeconds(10));
     }
 
+    // 다음 추천 AI 서버 호출
+    // 최근 이수한 강좌의 카테고리 기반으로 유사 강좌 추천 목록 받아옴
+    public RecommendationAiResponse getRecommendations(RecommendationAiRequest request) {
+        return aiWebClient.post()
+                .uri("/internal/ai/recommendations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(RecommendationAiResponse.class)
+                .block(Duration.ofSeconds(10));
+    }
+
     private QuizGenerateAiResponse.OptionDto createOption(String id, String text) {
         QuizGenerateAiResponse.OptionDto option = new QuizGenerateAiResponse.OptionDto();
         option.setId(id);
         option.setText(text);
         return option;
     }
+
+
 }

--- a/src/main/java/com/example/kuriq/controller/UserController.java
+++ b/src/main/java/com/example/kuriq/controller/UserController.java
@@ -1,10 +1,12 @@
 package com.example.kuriq.controller;
 
 
+import com.example.kuriq.dto.course.response.NextCourseResponse;
 import com.example.kuriq.dto.notification.request.NotificationUpdateRequest;
 import com.example.kuriq.dto.notification.response.NotificationResponse;
 import com.example.kuriq.dto.user.request.DeleteAccountRequest;
 import com.example.kuriq.dto.user.response.*;
+import com.example.kuriq.service.RecommendationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -28,6 +30,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final RecommendationService recommendationService; // 다음 추천 강좌
 
     @Operation(summary = "내 정보 조회")
     @SecurityRequirement(name = "bearerAuth")
@@ -106,6 +109,21 @@ public class UserController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") @Max(value = 50, message = "size는 최대 50까지 가능합니다") int size) {
         return ResponseEntity.ok(userService.getLearningHistory(userId, page, size));
+    }
+
+    @Operation(
+            summary = "다음 추천 강좌 조회",
+            description = "가장 최근 이수한 강좌의 카테고리와 난이도를 기반으로 다음 단계 강좌를 추천합니다. " +
+                    "이수 이력이 없거나 추천할 강좌가 없으면 204를 반환합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/me/recommendations")
+    public ResponseEntity<List<NextCourseResponse>> getRecommendation(
+            @AuthenticationPrincipal String userId) {
+        List<NextCourseResponse> result = recommendationService.getRecommendation(userId);
+        return result.isEmpty()
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.ok(result);
     }
 
 }

--- a/src/main/java/com/example/kuriq/dto/course/response/NextCourseResponse.java
+++ b/src/main/java/com/example/kuriq/dto/course/response/NextCourseResponse.java
@@ -1,0 +1,59 @@
+package com.example.kuriq.dto.course.response;
+
+import com.example.kuriq.entity.roadmap.Course;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@Schema(description = "다음 추천 강좌 응답")
+public class NextCourseResponse {
+
+    @Schema(description = "추천 강좌 ID", example = "abc123")
+    private String courseId;
+
+    @Schema(description = "강좌 제목", example = "머신러닝 입문")
+    private String title;
+
+    @Schema(description = "운영 기관", example = "서울대학교")
+    private String institution;
+
+    @Schema(description = "플랫폼", example = "K-MOOC")
+    private String platform;
+
+    @Schema(description = "카테고리", example = "IT/SW")
+    private String category;
+
+    @Schema(description = "난이도", example = "초급")
+    private String difficulty;
+
+    @Schema(description = "예상 학습 시간(시간)", example = "12.0")
+    private BigDecimal estimatedHours;
+
+    @Schema(description = "수강 신청 URL", example = "https://www.kmooc.kr/...")
+    private String url;
+
+    @Schema(description = "수료증 제공 여부", example = "true")
+    private Boolean hasCertificate;
+
+    @Schema(description = "큐리 추천 메시지", example = "파이썬 기초를 잘 마무리했어요! 다음으로 머신러닝 입문 과정은 어떨까요?")
+    private String message;
+
+    public static NextCourseResponse from(Course course, String message) {
+        return NextCourseResponse.builder()
+                .courseId(course.getId())
+                .title(course.getTitle())
+                .institution(course.getInstitution())
+                .platform(course.getPlatform().name())
+                .category(course.getCategory())
+                .difficulty(course.getDifficulty())
+                .estimatedHours(course.getEstimatedHours())
+                .url(course.getUrl())
+                .hasCertificate(course.getHasCertificate())
+                .message(message)
+                .build();
+    }
+}
+

--- a/src/main/java/com/example/kuriq/service/RecommendationService.java
+++ b/src/main/java/com/example/kuriq/service/RecommendationService.java
@@ -1,0 +1,132 @@
+package com.example.kuriq.service;
+
+import com.example.kuriq.client.AiClient;
+import com.example.kuriq.dto.course.response.NextCourseResponse;
+import com.example.kuriq.entity.roadmap.Course;
+import com.example.kuriq.entity.roadmap.LearningHistory;
+import com.example.kuriq.entity.roadmap.Platform;
+import com.example.kuriq.repository.roadmap.CourseRepository;
+import com.example.kuriq.repository.roadmap.LearningHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationService {
+
+    private final LearningHistoryRepository learningHistoryRepository;
+    private final CourseRepository courseRepository;
+    private final AiClient aiClient;
+
+    public List<NextCourseResponse> getRecommendation(String userId) {
+
+        // 1. 가장 최근 이수한 강좌 조회
+        List<LearningHistory> histories =
+                learningHistoryRepository.findByUserIdOrderByCompletedAtDesc(userId,
+                        PageRequest.of(0, 1));
+
+        if (histories.isEmpty()) {
+            return List.of();
+        }
+
+        String lastCourseId = histories.get(0).getCourseId();
+
+        // 2. 해당 강좌의 카테고리 조회
+        Optional<Course> lastCourseOpt = courseRepository.findById(lastCourseId);
+        if (lastCourseOpt.isEmpty()) {
+            return List.of();
+        }
+
+        Course lastCourse = lastCourseOpt.get();
+        String category = lastCourse.getCategory();
+
+        if (category == null) {
+            return List.of();
+        }
+
+        // 3. AI 서버에 벡터 유사도 기반 추천 요청
+        String aiCourseId = lastCourse.getPlatform().name() + "_" + lastCourse.getPlatformCourseId();
+
+        AiClient.RecommendationAiResponse aiResponse;
+        try {
+            aiResponse = aiClient.getRecommendations(
+                    AiClient.RecommendationAiRequest.builder()
+                            .courseId(aiCourseId)
+                            .courseTitle(lastCourse.getTitle())
+                            .category(category)
+                            .top_k(5)
+                            .build()
+            );
+        } catch (Exception e) {
+            log.error("[추천] AI 서버 호출 실패: {}", e.getMessage());
+            return List.of();
+        }
+
+        if (aiResponse == null || aiResponse.getCourses() == null || aiResponse.getCourses().isEmpty()) {
+            return List.of();
+        }
+
+        // 4. AI 서버 응답 강좌 최대 3개를 MySQL에서 조회
+        List<NextCourseResponse> result = new ArrayList<>();
+
+        for (AiClient.RecommendationAiResponse.RecommendationCourseDto recommended
+                : aiResponse.getCourses().subList(0, Math.min(3, aiResponse.getCourses().size()))) {
+
+            // course_id 형식: "LLL_PORTAL_2390297" → platform + platformCourseId 분리
+            String courseIdRaw = recommended.getCourse_id();
+            int lastIdx = courseIdRaw.lastIndexOf("_");
+            if (lastIdx < 0) continue;
+
+            String platformStr = courseIdRaw.substring(0, lastIdx);   // LLL_PORTAL
+            String platformCourseId = courseIdRaw.substring(lastIdx + 1); // 2390297
+            String message = buildMessage(lastCourse.getTitle(), recommended.getTitle());
+
+            Optional<Course> courseOpt = Optional.empty();
+            try {
+                Platform platform = Platform.valueOf(platformStr);
+                courseOpt = courseRepository.findByPlatformAndPlatformCourseId(platform, platformCourseId);
+            } catch (IllegalArgumentException e) {
+                log.warn("[추천] 알 수 없는 플랫폼: {}", platformStr);
+            }
+
+            if (courseOpt.isPresent()) {
+                result.add(NextCourseResponse.from(courseOpt.get(), message));
+            } else {
+                // courses 테이블에 없으면 AI 응답 데이터로 직접 구성
+                result.add(NextCourseResponse.builder()
+                        .courseId(recommended.getCourse_id())
+                        .title(recommended.getTitle())
+                        .institution(recommended.getInstitution())
+                        .platform(null)
+                        .category(recommended.getCategory())
+                        .difficulty(null)
+                        .estimatedHours(null)
+                        .url(null)
+                        .hasCertificate(null)
+                        .message(message)
+                        .build());
+            }
+        }
+        return result;
+    }
+
+    // 큐리 추천 메시지 생성
+    private String buildMessage(String lastTitle, String nextTitle) {
+        // 마지막 글자 받침 여부에 따라 을/를 선택
+        char lastChar = lastTitle.charAt(lastTitle.length() - 1);
+        boolean hasBatchim = (lastChar - 0xAC00) % 28 != 0;
+        String eul = hasBatchim ? "을" : "를";
+
+        return String.format("%s%s 잘 마무리했어요! 다음으로 %s 과정은 어떨까요?",
+                lastTitle, eul, nextTitle);
+    }
+}


### PR DESCRIPTION
## 구현 내용

- 가장 최근 이수한 강좌의 카테고리 기반으로 AI 서버에 벡터 유사도 검색 요청
- 추천 강좌 최대 3개 반환
- 이수한 강좌 제외, MySQL에서 강좌 정보 조회
- 이수 이력 없거나 추천 강좌 없으면 204 반환
- 큐리 추천 메시지 포함 (한국어 조사 자동 판별)
